### PR TITLE
Add bme68x lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(GPS_NON_BLOCKING "Enable GPS Blocking/Non-Blocking Feature" ON)
 
 # Add the CubeMX library
 add_subdirectory(CubeMX/cmake/stm32cubemx)
+add_subdirectory(libs/common)
 add_subdirectory(libs/gps)
 add_subdirectory(libs/bme68x)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(GPS_NON_BLOCKING "Enable GPS Blocking/Non-Blocking Feature" ON)
 # Add the CubeMX library
 add_subdirectory(CubeMX/cmake/stm32cubemx)
 add_subdirectory(libs/gps)
+add_subdirectory(libs/bme68x)
 
 # Add tests
 add_subdirectory(tests/si_write_and_read_test)
@@ -24,4 +25,5 @@ add_subdirectory(apps/uart_echo_app)
 
 # Add tests
 add_subdirectory(tests/gps_simple_test)
+add_subdirectory(tests/bme68x_test)
 

--- a/CubeMX/Inc/tim.h
+++ b/CubeMX/Inc/tim.h
@@ -35,12 +35,30 @@ extern "C" {
 extern TIM_HandleTypeDef htim2;
 
 /* USER CODE BEGIN Private defines */
+extern volatile uint8_t delay_complete;
 
 /* USER CODE END Private defines */
 
 void MX_TIM2_Init(void);
 
 /* USER CODE BEGIN Prototypes */
+
+/**
+ * @brief Example implementation for a microsecond delay callback
+ *
+ * Used to set the delay_us function pointer on the bme68x_dev device struct.
+ * This callback is used throughout the Bosch library whenever a microsecond
+ * delay is necessary for proper device functioning.
+ *
+ * @param[in] period_us Duration of the delay in microseconds
+ * @param[in] intf_ptr Pointer to the interface descriptor
+ *
+ * @note: intf_ptr is not used by this function, but needed to satisfy the
+ * callback function signature
+ */
+void delay_us_timer(uint32_t us, void *intf_ptr);
+
+void app_timer_elapsed_hook(TIM_HandleTypeDef *htim);
 
 /* USER CODE END Prototypes */
 

--- a/CubeMX/Src/tim.c
+++ b/CubeMX/Src/tim.c
@@ -21,6 +21,7 @@
 #include "tim.h"
 
 /* USER CODE BEGIN 0 */
+volatile uint8_t delay_complete = 0;
 
 /* USER CODE END 0 */
 
@@ -107,5 +108,41 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* tim_baseHandle)
 }
 
 /* USER CODE BEGIN 1 */
+/** Example implementation for a microsecond delay callback */
+void delay_us_timer(uint32_t us, void *intf_ptr)
+{
+  (void)intf_ptr;
+  /* Reset completion flag */
+  delay_complete = 0;
+
+  /* Set the timer period for the desired delay */
+  __HAL_TIM_SET_COUNTER(&htim2, 0);
+  __HAL_TIM_SET_AUTORELOAD(&htim2, us - 1);
+
+  /* Clear any pending interrupts */
+  __HAL_TIM_CLEAR_IT(&htim2, TIM_IT_UPDATE);
+
+  /* Start the timer with interrupts */
+  HAL_TIM_Base_Start_IT(&htim2);
+
+  /* Wait for completion (via interrupt) */
+  // This is a blocking delay, but it allows the CPU to enter
+  // a low-power mode during the wait if needed
+  while (delay_complete == 0)
+  {
+    /* Add memory barrier to prevent removal of this code with compiler optimization*/
+    __DSB();
+  }
+}
+
+/* Callback: executed when timer period elapses */
+void app_timer_elapsed_hook(TIM_HandleTypeDef *htim)
+{
+  if (htim->Instance == TIM2)
+  {
+    delay_complete = 1;
+    HAL_TIM_Base_Stop_IT(&htim2);
+  }
+}
 
 /* USER CODE END 1 */

--- a/libs/bme68x/CMakeLists.txt
+++ b/libs/bme68x/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Bosch BME68x Library CMakeLists.txt
+cmake_minimum_required(VERSION 3.22)
+project(bme68x)
+
+# Create the BME68x library
+add_library(bme68x STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/Src/bme68x.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Src/bme68x_driver.c
+)
+
+target_compile_definitions(bme68x PUBLIC
+    BME68X_DO_NOT_USE_FPU
+)
+
+# Define include directories
+target_include_directories(bme68x PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/Inc
+)
+
+
+message(STATUS "Building BME68x library")
+
+# Link with required dependencies
+target_link_libraries(bme68x PUBLIC
+    stm32cubemx
+    # Add dependencies here
+)
+
+message(STATUS "Added BME68x library")

--- a/libs/bme68x/Inc/bme68x.h
+++ b/libs/bme68x/Inc/bme68x.h
@@ -1,0 +1,323 @@
+/**
+ * Copyright (c) 2023 Bosch Sensortec GmbH. All rights reserved.
+ *
+ * BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file       bme68x.h
+ * @date       2023-02-07
+ * @version    v4.4.8
+ *
+ */
+
+/*!
+ * @defgroup bme68x BME68X
+ * @brief <a href="https://www.bosch-sensortec.com/bst/products/all_products/bme680">Product Overview</a>
+ * and  <a href="https://github.com/BoschSensortec/BME68x-Sensor-API">Sensor API Source Code</a>
+ */
+
+#ifndef BME68X_H_
+#define BME68X_H_
+
+#include "bme68x_defs.h"
+
+/* CPP guard */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  /**
+   * \ingroup bme68x
+   * \defgroup bme68xApiInit Initialization
+   * @brief Initialize the sensor and device structure
+   */
+
+  /*!
+   * \ingroup bme68xApiInit
+   * \page bme68x_api_bme68x_init bme68x_init
+   * \code
+   * int8_t bme68x_init(struct bme68x_dev *dev);
+   * \endcode
+   * @details This API reads the chip-id of the sensor which is the first step to
+   * verify the sensor and also calibrates the sensor
+   * As this API is the entry point, call this API before using other APIs.
+   *
+   * @param[in,out] dev : Structure instance of bme68x_dev
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_init(struct bme68x_dev *dev);
+
+  /**
+   * \ingroup bme68x
+   * \defgroup bme68xApiRegister Registers
+   * @brief Generic API for accessing sensor registers
+   */
+
+  /*!
+   * \ingroup bme68xApiRegister
+   * \page bme68x_api_bme68x_set_regs bme68x_set_regs
+   * \code
+   * int8_t bme68x_set_regs(const uint8_t reg_addr, const uint8_t *reg_data, uint32_t len, struct bme68x_dev *dev)
+   * \endcode
+   * @details This API writes the given data to the register address of the sensor
+   *
+   * @param[in] reg_addr : Register addresses to where the data is to be written
+   * @param[in] reg_data : Pointer to data buffer which is to be written
+   *                       in the reg_addr of sensor.
+   * @param[in] len      : No of bytes of data to write
+   * @param[in,out] dev  : Structure instance of bme68x_dev
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_set_regs(const uint8_t *reg_addr, const uint8_t *reg_data, uint32_t len, struct bme68x_dev *dev);
+
+  /*!
+   * \ingroup bme68xApiRegister
+   * \page bme68x_api_bme68x_get_regs bme68x_get_regs
+   * \code
+   * int8_t bme68x_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct bme68x_dev *dev)
+   * \endcode
+   * @details This API reads the data from the given register address of sensor.
+   *
+   * @param[in] reg_addr  : Register address from where the data to be read
+   * @param[out] reg_data : Pointer to data buffer to store the read data.
+   * @param[in] len       : No of bytes of data to be read.
+   * @param[in,out] dev   : Structure instance of bme68x_dev.
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct bme68x_dev *dev);
+
+  /**
+   * \ingroup bme68x
+   * \defgroup bme68xApiSystem System
+   * @brief API that performs system-level operations
+   */
+
+  /*!
+   * \ingroup bme68xApiSystem
+   * \page bme68x_api_bme68x_soft_reset bme68x_soft_reset
+   * \code
+   * int8_t bme68x_soft_reset(struct bme68x_dev *dev);
+   * \endcode
+   * @details This API soft-resets the sensor.
+   *
+   * @param[in,out] dev : Structure instance of bme68x_dev.
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_soft_reset(struct bme68x_dev *dev);
+
+  /**
+   * \ingroup bme68x
+   * \defgroup bme68xApiOm Operation mode
+   * @brief API to configure operation mode
+   */
+
+  /*!
+   * \ingroup bme68xApiOm
+   * \page bme68x_api_bme68x_set_op_mode bme68x_set_op_mode
+   * \code
+   * int8_t bme68x_set_op_mode(const uint8_t op_mode, struct bme68x_dev *dev);
+   * \endcode
+   * @details This API is used to set the operation mode of the sensor
+   * @param[in] op_mode : Desired operation mode.
+   * @param[in] dev     : Structure instance of bme68x_dev
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_set_op_mode(const uint8_t op_mode, struct bme68x_dev *dev);
+
+  /*!
+   * \ingroup bme68xApiOm
+   * \page bme68x_api_bme68x_get_op_mode bme68x_get_op_mode
+   * \code
+   * int8_t bme68x_get_op_mode(uint8_t *op_mode, struct bme68x_dev *dev);
+   * \endcode
+   * @details This API is used to get the operation mode of the sensor.
+   *
+   * @param[out] op_mode : Desired operation mode.
+   * @param[in,out] dev : Structure instance of bme68x_dev
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_get_op_mode(uint8_t *op_mode, struct bme68x_dev *dev);
+
+  /*!
+   * \ingroup bme68xApiConfig
+   * \page bme68x_api_bme68x_get_meas_dur bme68x_get_meas_dur
+   * \code
+   * uint32_t bme68x_get_meas_dur(const uint8_t op_mode, struct bme68x_conf *conf, struct bme68x_dev *dev);
+   * \endcode
+   * @details This API is used to get the remaining duration that can be used for heating.
+   *
+   * @param[in] op_mode : Desired operation mode.
+   * @param[in] conf    : Desired sensor configuration.
+   * @param[in] dev     : Structure instance of bme68x_dev
+   *
+   * @return Measurement duration calculated in microseconds
+   */
+  uint32_t bme68x_get_meas_dur(const uint8_t op_mode, struct bme68x_conf *conf, struct bme68x_dev *dev);
+
+  /**
+   * \ingroup bme68x
+   * \defgroup bme68xApiData Data Read out
+   * @brief Read our data from the sensor
+   */
+
+  /*!
+   * \ingroup bme68xApiData
+   * \page bme68x_api_bme68x_get_data bme68x_get_data
+   * \code
+   * int8_t bme68x_get_data(uint8_t op_mode, struct bme68x_data *data, uint8_t *n_data, struct bme68x_dev *dev);
+   * \endcode
+   * @details This API reads the pressure, temperature and humidity and gas data
+   * from the sensor, compensates the data and store it in the bme68x_data
+   * structure instance passed by the user.
+   *
+   * @param[in]  op_mode : Expected operation mode.
+   * @param[out] data    : Structure instance to hold the data.
+   * @param[out] n_data  : Number of data instances available.
+   * @param[in,out] dev  : Structure instance of bme68x_dev
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_get_data(uint8_t op_mode, struct bme68x_data *data, uint8_t *n_data, struct bme68x_dev *dev);
+
+  /**
+   * \ingroup bme68x
+   * \defgroup bme68xApiConfig Configuration
+   * @brief Configuration API of sensor
+   */
+
+  /*!
+   * \ingroup bme68xApiConfig
+   * \page bme68x_api_bme68x_set_conf bme68x_set_conf
+   * \code
+   * int8_t bme68x_set_conf(struct bme68x_conf *conf, struct bme68x_dev *dev);
+   * \endcode
+   * @details This API is used to set the oversampling and filter configuration
+   *
+   * @param[in] conf    : Desired sensor configuration.
+   * @param[in,out] dev : Structure instance of bme68x_dev.
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_set_conf(struct bme68x_conf *conf, struct bme68x_dev *dev);
+
+  /*!
+   * \ingroup bme68xApiConfig
+   * \page bme68x_api_bme68x_get_conf bme68x_get_conf
+   * \code
+   * int8_t bme68x_get_conf(struct bme68x_conf *conf, struct bme68x_dev *dev);
+   * \endcode
+   * @details This API is used to get the oversampling and filter configuration
+   *
+   * @param[out] conf   : Present sensor configuration.
+   * @param[in,out] dev : Structure instance of bme68x_dev.
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_get_conf(struct bme68x_conf *conf, struct bme68x_dev *dev);
+
+  /*!
+   * \ingroup bme68xApiConfig
+   * \page bme68x_api_bme68x_set_heatr_conf bme68x_set_heatr_conf
+   * \code
+   * int8_t bme68x_set_heatr_conf(uint8_t op_mode, const struct bme68x_heatr_conf *conf, struct bme68x_dev *dev);
+   * \endcode
+   * @details This API is used to set the gas configuration of the sensor.
+   *
+   * @param[in] op_mode : Expected operation mode of the sensor.
+   * @param[in] conf    : Desired heating configuration.
+   * @param[in,out] dev : Structure instance of bme68x_dev.
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_set_heatr_conf(uint8_t op_mode, const struct bme68x_heatr_conf *conf, struct bme68x_dev *dev);
+
+  /*!
+   * \ingroup bme68xApiConfig
+   * \page bme68x_api_bme68x_get_heatr_conf bme68x_get_heatr_conf
+   * \code
+   * int8_t bme68x_get_heatr_conf(const struct bme68x_heatr_conf *conf, struct bme68x_dev *dev);
+   * \endcode
+   * @details This API is used to get the gas configuration of the sensor.
+   *
+   * @param[out] conf   : Current configurations of the gas sensor.
+   * @param[in,out] dev : Structure instance of bme68x_dev.
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_get_heatr_conf(const struct bme68x_heatr_conf *conf, struct bme68x_dev *dev);
+
+  /*!
+   * \ingroup bme68xApiSystem
+   * \page bme68x_api_bme68x_selftest_check bme68x_selftest_check
+   * \code
+   * int8_t bme68x_selftest_check(const struct bme68x_dev *dev);
+   * \endcode
+   * @details This API performs Self-test of low gas variant of BME68X
+   *
+   * @param[in, out]   dev  : Structure instance of bme68x_dev
+   *
+   * @return Result of API execution status
+   * @retval 0 -> Success
+   * @retval < 0 -> Fail
+   */
+  int8_t bme68x_selftest_check(const struct bme68x_dev *dev);
+
+#ifdef __cplusplus
+}
+#endif /* End of CPP guard */
+#endif /* BME68X_H_ */

--- a/libs/bme68x/Inc/bme68x_defs.h
+++ b/libs/bme68x/Inc/bme68x_defs.h
@@ -1,0 +1,882 @@
+/**
+ * Copyright (c) 2023 Bosch Sensortec GmbH. All rights reserved.
+ *
+ * BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file       bme68x_defs.h
+ * @date       2023-02-07
+ * @version    v4.4.8
+ *
+ */
+
+/*! @cond DOXYGEN_SUPRESS */
+
+#ifndef BME68X_DEFS_H_
+#define BME68X_DEFS_H_
+
+/********************************************************* */
+/*!             Header includes                           */
+/********************************************************* */
+#ifdef __KERNEL__
+#include <linux/types.h>
+#include <linux/kernel.h>
+#else
+#include <stdint.h>
+#include <stddef.h>
+#endif
+
+/********************************************************* */
+/*!               Common Macros                           */
+/********************************************************* */
+#ifdef __KERNEL__
+#if !defined(UINT8_C) && !defined(INT8_C)
+#define INT8_C(x) S8_C(x)
+#define UINT8_C(x) U8_C(x)
+#endif
+
+#if !defined(UINT16_C) && !defined(INT16_C)
+#define INT16_C(x) S16_C(x)
+#define UINT16_C(x) U16_C(x)
+#endif
+
+#if !defined(INT32_C) && !defined(UINT32_C)
+#define INT32_C(x) S32_C(x)
+#define UINT32_C(x) U32_C(x)
+#endif
+
+#if !defined(INT64_C) && !defined(UINT64_C)
+#define INT64_C(x) S64_C(x)
+#define UINT64_C(x) U64_C(x)
+#endif
+#endif
+
+/*! C standard macros */
+#ifndef NULL
+#ifdef __cplusplus
+#define NULL 0
+#else
+#define NULL ((void *)0)
+#endif
+#endif
+
+#ifndef BME68X_DO_NOT_USE_FPU
+
+/* Comment or un-comment the macro to provide floating point data output */
+#define BME68X_USE_FPU
+#endif
+
+/* Period between two polls (value can be given by user) */
+#ifndef BME68X_PERIOD_POLL
+#define BME68X_PERIOD_POLL UINT32_C(10000)
+#endif
+
+/* BME68X unique chip identifier */
+#define BME68X_CHIP_ID UINT8_C(0x61)
+
+/* Period for a soft reset */
+#define BME68X_PERIOD_RESET UINT32_C(10000)
+
+/* BME68X lower I2C address */
+#define BME68X_I2C_ADDR_LOW UINT8_C(0x76)
+
+/* BME68X higher I2C address */
+#define BME68X_I2C_ADDR_HIGH UINT8_C(0x77)
+
+/* Soft reset command */
+#define BME68X_SOFT_RESET_CMD UINT8_C(0xb6)
+
+/* Return code definitions */
+/* Success */
+#define BME68X_OK INT8_C(0)
+
+/* Errors */
+/* Null pointer passed */
+#define BME68X_E_NULL_PTR INT8_C(-1)
+
+/* Communication failure */
+#define BME68X_E_COM_FAIL INT8_C(-2)
+
+/* Sensor not found */
+#define BME68X_E_DEV_NOT_FOUND INT8_C(-3)
+
+/* Incorrect length parameter */
+#define BME68X_E_INVALID_LENGTH INT8_C(-4)
+
+/* Self test fail error */
+#define BME68X_E_SELF_TEST INT8_C(-5)
+
+/* Warnings */
+/* Define a valid operation mode */
+#define BME68X_W_DEFINE_OP_MODE INT8_C(1)
+
+/* No new data was found */
+#define BME68X_W_NO_NEW_DATA INT8_C(2)
+
+/* Define the shared heating duration */
+#define BME68X_W_DEFINE_SHD_HEATR_DUR INT8_C(3)
+
+/* Information - only available via bme68x_dev.info_msg */
+#define BME68X_I_PARAM_CORR UINT8_C(1)
+
+/* Register map addresses in I2C */
+/* Register for 3rd group of coefficients */
+#define BME68X_REG_COEFF3 UINT8_C(0x00)
+
+/* 0th Field address*/
+#define BME68X_REG_FIELD0 UINT8_C(0x1d)
+
+/* 0th Current DAC address*/
+#define BME68X_REG_IDAC_HEAT0 UINT8_C(0x50)
+
+/* 0th Res heat address */
+#define BME68X_REG_RES_HEAT0 UINT8_C(0x5a)
+
+/* 0th Gas wait address */
+#define BME68X_REG_GAS_WAIT0 UINT8_C(0x64)
+
+/* Shared heating duration address */
+#define BME68X_REG_SHD_HEATR_DUR UINT8_C(0x6E)
+
+/* CTRL_GAS_0 address */
+#define BME68X_REG_CTRL_GAS_0 UINT8_C(0x70)
+
+/* CTRL_GAS_1 address */
+#define BME68X_REG_CTRL_GAS_1 UINT8_C(0x71)
+
+/* CTRL_HUM address */
+#define BME68X_REG_CTRL_HUM UINT8_C(0x72)
+
+/* CTRL_MEAS address */
+#define BME68X_REG_CTRL_MEAS UINT8_C(0x74)
+
+/* CONFIG address */
+#define BME68X_REG_CONFIG UINT8_C(0x75)
+
+/* MEM_PAGE address */
+#define BME68X_REG_MEM_PAGE UINT8_C(0xf3)
+
+/* Unique ID address */
+#define BME68X_REG_UNIQUE_ID UINT8_C(0x83)
+
+/* Register for 1st group of coefficients */
+#define BME68X_REG_COEFF1 UINT8_C(0x8a)
+
+/* Chip ID address */
+#define BME68X_REG_CHIP_ID UINT8_C(0xd0)
+
+/* Soft reset address */
+#define BME68X_REG_SOFT_RESET UINT8_C(0xe0)
+
+/* Register for 2nd group of coefficients */
+#define BME68X_REG_COEFF2 UINT8_C(0xe1)
+
+/* Variant ID Register */
+#define BME68X_REG_VARIANT_ID UINT8_C(0xF0)
+
+/* Enable/Disable macros */
+
+/* Enable */
+#define BME68X_ENABLE UINT8_C(0x01)
+
+/* Disable */
+#define BME68X_DISABLE UINT8_C(0x00)
+
+/* Variant ID macros */
+
+/* Low Gas variant */
+#define BME68X_VARIANT_GAS_LOW UINT8_C(0x00)
+
+/* High Gas variant */
+#define BME68X_VARIANT_GAS_HIGH UINT8_C(0x01)
+
+/* Oversampling setting macros */
+
+/* Switch off measurement */
+#define BME68X_OS_NONE UINT8_C(0)
+
+/* Perform 1 measurement */
+#define BME68X_OS_1X UINT8_C(1)
+
+/* Perform 2 measurements */
+#define BME68X_OS_2X UINT8_C(2)
+
+/* Perform 4 measurements */
+#define BME68X_OS_4X UINT8_C(3)
+
+/* Perform 8 measurements */
+#define BME68X_OS_8X UINT8_C(4)
+
+/* Perform 16 measurements */
+#define BME68X_OS_16X UINT8_C(5)
+
+/* IIR Filter settings */
+
+/* Switch off the filter */
+#define BME68X_FILTER_OFF UINT8_C(0)
+
+/* Filter coefficient of 2 */
+#define BME68X_FILTER_SIZE_1 UINT8_C(1)
+
+/* Filter coefficient of 4 */
+#define BME68X_FILTER_SIZE_3 UINT8_C(2)
+
+/* Filter coefficient of 8 */
+#define BME68X_FILTER_SIZE_7 UINT8_C(3)
+
+/* Filter coefficient of 16 */
+#define BME68X_FILTER_SIZE_15 UINT8_C(4)
+
+/* Filter coefficient of 32 */
+#define BME68X_FILTER_SIZE_31 UINT8_C(5)
+
+/* Filter coefficient of 64 */
+#define BME68X_FILTER_SIZE_63 UINT8_C(6)
+
+/* Filter coefficient of 128 */
+#define BME68X_FILTER_SIZE_127 UINT8_C(7)
+
+/* Operating mode macros */
+
+/* Sleep operation mode */
+#define BME68X_SLEEP_MODE UINT8_C(0)
+
+/* Forced operation mode */
+#define BME68X_FORCED_MODE UINT8_C(1)
+
+/* Coefficient index macros */
+
+/* Length for all coefficients */
+#define BME68X_LEN_COEFF_ALL UINT8_C(42)
+
+/* Length for 1st group of coefficients */
+#define BME68X_LEN_COEFF1 UINT8_C(23)
+
+/* Length for 2nd group of coefficients */
+#define BME68X_LEN_COEFF2 UINT8_C(14)
+
+/* Length for 3rd group of coefficients */
+#define BME68X_LEN_COEFF3 UINT8_C(5)
+
+/* Length of the field */
+#define BME68X_LEN_FIELD UINT8_C(17)
+
+/* Length between two fields */
+#define BME68X_LEN_FIELD_OFFSET UINT8_C(17)
+
+/* Length of the configuration register */
+#define BME68X_LEN_CONFIG UINT8_C(5)
+
+/* Length of the interleaved buffer */
+#define BME68X_LEN_INTERLEAVE_BUFF UINT8_C(20)
+
+/* Coefficient index macros */
+
+/* Coefficient T2 LSB position */
+#define BME68X_IDX_T2_LSB (0)
+
+/* Coefficient T2 MSB position */
+#define BME68X_IDX_T2_MSB (1)
+
+/* Coefficient T3 position */
+#define BME68X_IDX_T3 (2)
+
+/* Coefficient P1 LSB position */
+#define BME68X_IDX_P1_LSB (4)
+
+/* Coefficient P1 MSB position */
+#define BME68X_IDX_P1_MSB (5)
+
+/* Coefficient P2 LSB position */
+#define BME68X_IDX_P2_LSB (6)
+
+/* Coefficient P2 MSB position */
+#define BME68X_IDX_P2_MSB (7)
+
+/* Coefficient P3 position */
+#define BME68X_IDX_P3 (8)
+
+/* Coefficient P4 LSB position */
+#define BME68X_IDX_P4_LSB (10)
+
+/* Coefficient P4 MSB position */
+#define BME68X_IDX_P4_MSB (11)
+
+/* Coefficient P5 LSB position */
+#define BME68X_IDX_P5_LSB (12)
+
+/* Coefficient P5 MSB position */
+#define BME68X_IDX_P5_MSB (13)
+
+/* Coefficient P7 position */
+#define BME68X_IDX_P7 (14)
+
+/* Coefficient P6 position */
+#define BME68X_IDX_P6 (15)
+
+/* Coefficient P8 LSB position */
+#define BME68X_IDX_P8_LSB (18)
+
+/* Coefficient P8 MSB position */
+#define BME68X_IDX_P8_MSB (19)
+
+/* Coefficient P9 LSB position */
+#define BME68X_IDX_P9_LSB (20)
+
+/* Coefficient P9 MSB position */
+#define BME68X_IDX_P9_MSB (21)
+
+/* Coefficient P10 position */
+#define BME68X_IDX_P10 (22)
+
+/* Coefficient H2 MSB position */
+#define BME68X_IDX_H2_MSB (23)
+
+/* Coefficient H2 LSB position */
+#define BME68X_IDX_H2_LSB (24)
+
+/* Coefficient H1 LSB position */
+#define BME68X_IDX_H1_LSB (24)
+
+/* Coefficient H1 MSB position */
+#define BME68X_IDX_H1_MSB (25)
+
+/* Coefficient H3 position */
+#define BME68X_IDX_H3 (26)
+
+/* Coefficient H4 position */
+#define BME68X_IDX_H4 (27)
+
+/* Coefficient H5 position */
+#define BME68X_IDX_H5 (28)
+
+/* Coefficient H6 position */
+#define BME68X_IDX_H6 (29)
+
+/* Coefficient H7 position */
+#define BME68X_IDX_H7 (30)
+
+/* Coefficient T1 LSB position */
+#define BME68X_IDX_T1_LSB (31)
+
+/* Coefficient T1 MSB position */
+#define BME68X_IDX_T1_MSB (32)
+
+/* Coefficient GH2 LSB position */
+#define BME68X_IDX_GH2_LSB (33)
+
+/* Coefficient GH2 MSB position */
+#define BME68X_IDX_GH2_MSB (34)
+
+/* Coefficient GH1 position */
+#define BME68X_IDX_GH1 (35)
+
+/* Coefficient GH3 position */
+#define BME68X_IDX_GH3 (36)
+
+/* Coefficient res heat value position */
+#define BME68X_IDX_RES_HEAT_VAL (37)
+
+/* Coefficient res heat range position */
+#define BME68X_IDX_RES_HEAT_RANGE (39)
+
+/* Coefficient range switching error position */
+#define BME68X_IDX_RANGE_SW_ERR (41)
+
+/* Gas measurement macros */
+
+/* Disable gas measurement */
+#define BME68X_DISABLE_GAS_MEAS UINT8_C(0x00)
+
+/* Enable gas measurement low */
+#define BME68X_ENABLE_GAS_MEAS_L UINT8_C(0x01)
+
+/* Enable gas measurement high */
+#define BME68X_ENABLE_GAS_MEAS_H UINT8_C(0x02)
+
+/* Heater control macros */
+
+/* Enable heater */
+#define BME68X_ENABLE_HEATER UINT8_C(0x00)
+
+/* Disable heater */
+#define BME68X_DISABLE_HEATER UINT8_C(0x01)
+
+#ifdef BME68X_USE_FPU
+
+/* 0 degree Celsius */
+#define BME68X_MIN_TEMPERATURE INT16_C(0)
+
+/* 60 degree Celsius */
+#define BME68X_MAX_TEMPERATURE INT16_C(60)
+
+/* 900 hecto Pascals */
+#define BME68X_MIN_PRESSURE UINT32_C(90000)
+
+/* 1100 hecto Pascals */
+#define BME68X_MAX_PRESSURE UINT32_C(110000)
+
+/* 20% relative humidity */
+#define BME68X_MIN_HUMIDITY UINT32_C(20)
+
+/* 80% relative humidity*/
+#define BME68X_MAX_HUMIDITY UINT32_C(80)
+#else
+
+/* 0 degree Celsius */
+#define BME68X_MIN_TEMPERATURE INT16_C(0)
+
+/* 60 degree Celsius */
+#define BME68X_MAX_TEMPERATURE INT16_C(6000)
+
+/* 900 hecto Pascals */
+#define BME68X_MIN_PRESSURE UINT32_C(90000)
+
+/* 1100 hecto Pascals */
+#define BME68X_MAX_PRESSURE UINT32_C(110000)
+
+/* 20% relative humidity */
+#define BME68X_MIN_HUMIDITY UINT32_C(20000)
+
+/* 80% relative humidity*/
+#define BME68X_MAX_HUMIDITY UINT32_C(80000)
+
+#endif
+
+#define BME68X_HEATR_DUR1 UINT16_C(1000)
+#define BME68X_HEATR_DUR2 UINT16_C(2000)
+#define BME68X_HEATR_DUR1_DELAY UINT32_C(1000000)
+#define BME68X_HEATR_DUR2_DELAY UINT32_C(2000000)
+#define BME68X_N_MEAS UINT8_C(6)
+#define BME68X_LOW_TEMP UINT8_C(150)
+#define BME68X_HIGH_TEMP UINT16_C(350)
+
+/* Mask macros */
+/* Mask for number of conversions */
+#define BME68X_NBCONV_MSK UINT8_C(0X0f)
+
+/* Mask for IIR filter */
+#define BME68X_FILTER_MSK UINT8_C(0X1c)
+
+/* Mask for temperature oversampling */
+#define BME68X_OST_MSK UINT8_C(0Xe0)
+
+/* Mask for pressure oversampling */
+#define BME68X_OSP_MSK UINT8_C(0X1c)
+
+/* Mask for humidity oversampling */
+#define BME68X_OSH_MSK UINT8_C(0X07)
+
+/* Mask for heater control */
+#define BME68X_HCTRL_MSK UINT8_C(0x08)
+
+/* Mask for run gas */
+#define BME68X_RUN_GAS_MSK UINT8_C(0x30)
+
+/* Mask for operation mode */
+#define BME68X_MODE_MSK UINT8_C(0x03)
+
+/* Mask for res heat range */
+#define BME68X_RHRANGE_MSK UINT8_C(0x30)
+
+/* Mask for range switching error */
+#define BME68X_RSERROR_MSK UINT8_C(0xf0)
+
+/* Mask for new data */
+#define BME68X_NEW_DATA_MSK UINT8_C(0x80)
+
+/* Mask for gas index */
+#define BME68X_GAS_INDEX_MSK UINT8_C(0x0f)
+
+/* Mask for gas range */
+#define BME68X_GAS_RANGE_MSK UINT8_C(0x0f)
+
+/* Mask for gas measurement valid */
+#define BME68X_GASM_VALID_MSK UINT8_C(0x20)
+
+/* Mask for heater stability */
+#define BME68X_HEAT_STAB_MSK UINT8_C(0x10)
+
+/* Mask for the H1 calibration coefficient */
+#define BME68X_BIT_H1_DATA_MSK UINT8_C(0x0f)
+
+/* Position macros */
+
+/* Filter bit position */
+#define BME68X_FILTER_POS UINT8_C(2)
+
+/* Temperature oversampling bit position */
+#define BME68X_OST_POS UINT8_C(5)
+
+/* Pressure oversampling bit position */
+#define BME68X_OSP_POS UINT8_C(2)
+
+/* Run gas bit position */
+#define BME68X_RUN_GAS_POS UINT8_C(4)
+
+/* Heater control bit position */
+#define BME68X_HCTRL_POS UINT8_C(3)
+
+/* Macro to combine two 8 bit data's to form a 16 bit data */
+#define BME68X_CONCAT_BYTES(msb, lsb) (((uint16_t)msb << 8) | (uint16_t)lsb)
+
+/* Macro to set bits */
+#define BME68X_SET_BITS(reg_data, bitname, data) \
+  ((reg_data & ~(bitname##_MSK)) |               \
+   ((data << bitname##_POS) & bitname##_MSK))
+
+/* Macro to get bits */
+#define BME68X_GET_BITS(reg_data, bitname) ((reg_data & (bitname##_MSK)) >> \
+                                            (bitname##_POS))
+
+/* Macro to set bits starting from position 0 */
+#define BME68X_SET_BITS_POS_0(reg_data, bitname, data) \
+  ((reg_data & ~(bitname##_MSK)) |                     \
+   (data & bitname##_MSK))
+
+/* Macro to get bits starting from position 0 */
+#define BME68X_GET_BITS_POS_0(reg_data, bitname) (reg_data & (bitname##_MSK))
+
+/**
+ * BME68X_INTF_RET_TYPE is the read/write interface return type which can be overwritten by the build system.
+ * The default is set to int8_t.
+ */
+#ifndef BME68X_INTF_RET_TYPE
+#define BME68X_INTF_RET_TYPE int8_t
+#endif
+
+/**
+ * BME68X_INTF_RET_SUCCESS is the success return value read/write interface return type which can be
+ * overwritten by the build system. The default is set to 0. It is used to check for a successful
+ * execution of the read/write functions
+ */
+#ifndef BME68X_INTF_RET_SUCCESS
+#define BME68X_INTF_RET_SUCCESS INT8_C(0)
+#endif
+
+/********************************************************* */
+/*!               Function Pointers                       */
+/********************************************************* */
+
+/*!
+ * @brief Bus communication function pointer which should be mapped to
+ * the platform specific read functions of the user
+ *
+ * @param[in]     reg_addr : 8bit register address of the sensor
+ * @param[out]    reg_data : Data from the specified address
+ * @param[in]     length   : Length of the reg_data array
+ * @param[in,out] intf_ptr : Void pointer that can enable the linking of descriptors
+ *                           for interface related callbacks
+ * @retval 0 for Success
+ * @retval Non-zero for Failure
+ */
+typedef BME68X_INTF_RET_TYPE (*bme68x_read_fptr_t)(uint8_t reg_addr, uint8_t *reg_data, uint32_t length,
+                                                   void *intf_ptr);
+
+/*!
+ * @brief Bus communication function pointer which should be mapped to
+ * the platform specific write functions of the user
+ *
+ * @param[in]     reg_addr : 8bit register address of the sensor
+ * @param[out]    reg_data : Data to the specified address
+ * @param[in]     length   : Length of the reg_data array
+ * @param[in,out] intf_ptr : Void pointer that can enable the linking of descriptors
+ *                           for interface related callbacks
+ * @retval 0 for Success
+ * @retval Non-zero for Failure
+ *
+ */
+typedef BME68X_INTF_RET_TYPE (*bme68x_write_fptr_t)(uint8_t reg_addr, const uint8_t *reg_data, uint32_t length,
+                                                    void *intf_ptr);
+
+/*!
+ * @brief Delay function pointer which should be mapped to
+ * delay function of the user
+ *
+ * @param period - The time period in microseconds
+ * @param[in,out] intf_ptr : Void pointer that can enable the linking of descriptors
+ *                           for interface related callbacks
+ */
+typedef void (*bme68x_delay_us_fptr_t)(uint32_t period, void *intf_ptr);
+
+/*
+ * @brief Generic communication function pointer
+ * @param[in] dev_id: Place holder to store the id of the device structure
+ *                    Can be used to store the index of the Chip select or
+ *                    I2C address of the device.
+ * @param[in] reg_addr: Used to select the register the where data needs to
+ *                      be read from or written to.
+ * @param[in,out] reg_data: Data array to read/write
+ * @param[in] len: Length of the data array
+ */
+
+/* Structure definitions */
+
+/*
+ * @brief Sensor field data structure
+ */
+struct bme68x_data
+{
+  /*! Contains new_data, gasm_valid & heat_stab */
+  uint8_t status;
+
+  /*! The index of the heater profile used */
+  uint8_t gas_index;
+
+  /*! Measurement index to track order */
+  uint8_t meas_index;
+
+  /*! Heater resistance */
+  uint8_t res_heat;
+
+  /*! Current DAC */
+  uint8_t idac;
+
+  /*! Gas wait period */
+  uint8_t gas_wait;
+#ifndef BME68X_USE_FPU
+
+  /*! Temperature in degree celsius x100 */
+  int16_t temperature;
+
+  /*! Pressure in Pascal */
+  uint32_t pressure;
+
+  /*! Humidity in % relative humidity x1000 */
+  uint32_t humidity;
+
+  /*! Gas resistance in Ohms */
+  uint32_t gas_resistance;
+#else
+
+  /*! Temperature in degree celsius */
+  float temperature;
+
+  /*! Pressure in Pascal */
+  float pressure;
+
+  /*! Humidity in % relative humidity x1000 */
+  float humidity;
+
+  /*! Gas resistance in Ohms */
+  float gas_resistance;
+
+#endif
+};
+
+/*
+ * @brief Structure to hold the calibration coefficients
+ */
+struct bme68x_calib_data
+{
+  /*! Calibration coefficient for the humidity sensor */
+  uint16_t par_h1;
+
+  /*! Calibration coefficient for the humidity sensor */
+  uint16_t par_h2;
+
+  /*! Calibration coefficient for the humidity sensor */
+  int8_t par_h3;
+
+  /*! Calibration coefficient for the humidity sensor */
+  int8_t par_h4;
+
+  /*! Calibration coefficient for the humidity sensor */
+  int8_t par_h5;
+
+  /*! Calibration coefficient for the humidity sensor */
+  uint8_t par_h6;
+
+  /*! Calibration coefficient for the humidity sensor */
+  int8_t par_h7;
+
+  /*! Calibration coefficient for the gas sensor */
+  int8_t par_gh1;
+
+  /*! Calibration coefficient for the gas sensor */
+  int16_t par_gh2;
+
+  /*! Calibration coefficient for the gas sensor */
+  int8_t par_gh3;
+
+  /*! Calibration coefficient for the temperature sensor */
+  uint16_t par_t1;
+
+  /*! Calibration coefficient for the temperature sensor */
+  int16_t par_t2;
+
+  /*! Calibration coefficient for the temperature sensor */
+  int8_t par_t3;
+
+  /*! Calibration coefficient for the pressure sensor */
+  uint16_t par_p1;
+
+  /*! Calibration coefficient for the pressure sensor */
+  int16_t par_p2;
+
+  /*! Calibration coefficient for the pressure sensor */
+  int8_t par_p3;
+
+  /*! Calibration coefficient for the pressure sensor */
+  int16_t par_p4;
+
+  /*! Calibration coefficient for the pressure sensor */
+  int16_t par_p5;
+
+  /*! Calibration coefficient for the pressure sensor */
+  int8_t par_p6;
+
+  /*! Calibration coefficient for the pressure sensor */
+  int8_t par_p7;
+
+  /*! Calibration coefficient for the pressure sensor */
+  int16_t par_p8;
+
+  /*! Calibration coefficient for the pressure sensor */
+  int16_t par_p9;
+
+  /*! Calibration coefficient for the pressure sensor */
+  uint8_t par_p10;
+#ifndef BME68X_USE_FPU
+
+  /*! Variable to store the intermediate temperature coefficient */
+  int32_t t_fine;
+#else
+
+  /*! Variable to store the intermediate temperature coefficient */
+  float t_fine;
+#endif
+
+  /*! Heater resistance range coefficient */
+  uint8_t res_heat_range;
+
+  /*! Heater resistance value coefficient */
+  int8_t res_heat_val;
+
+  /*! Gas resistance range switching error coefficient */
+  int8_t range_sw_err;
+};
+
+/*
+ * @brief BME68X sensor settings structure which comprises of
+ * over-sampling and filter settings.
+ */
+struct bme68x_conf
+{
+  /*! Humidity oversampling. Refer @ref osx*/
+  uint8_t os_hum;
+
+  /*! Temperature oversampling. Refer @ref osx */
+  uint8_t os_temp;
+
+  /*! Pressure oversampling. Refer @ref osx */
+  uint8_t os_pres;
+
+  /*! Filter coefficient. Refer @ref filter*/
+  uint8_t filter;
+};
+
+/*
+ * @brief BME68X gas heater configuration
+ */
+struct bme68x_heatr_conf
+{
+  /*! Enable gas measurement. Refer @ref en_dis */
+  uint8_t enable;
+
+  /*! Store the heater temperature for forced mode degree Celsius */
+  uint16_t heatr_temp;
+
+  /*! Store the heating duration for forced mode in milliseconds */
+  uint16_t heatr_dur;
+
+  /*! Store the heater temperature profile in degree Celsius */
+  uint16_t *heatr_temp_prof;
+
+  /*! Store the heating duration profile in milliseconds */
+  uint16_t *heatr_dur_prof;
+
+  /*! Variable to store the length of the heating profile */
+  uint8_t profile_len;
+};
+
+/*
+ * @brief BME68X device structure
+ */
+struct bme68x_dev
+{
+  /*! Chip Id */
+  uint8_t chip_id;
+
+  /*!
+   * The interface pointer is used to enable the user
+   * to link their interface descriptors for reference during the
+   * implementation of the read and write interfaces to the
+   * hardware.
+   */
+  void *intf_ptr;
+
+  /*!
+   *             Variant id
+   * ----------------------------------------
+   *     Value   |           Variant
+   * ----------------------------------------
+   *      0      |   BME68X_VARIANT_GAS_LOW
+   *      1      |   BME68X_VARIANT_GAS_HIGH
+   * ----------------------------------------
+   */
+  uint32_t variant_id;
+
+  /*! Memory page used */
+  uint8_t mem_page;
+
+  /*! Ambient temperature in Degree C*/
+  int8_t amb_temp;
+
+  /*! Sensor calibration data */
+  struct bme68x_calib_data calib;
+
+  /*! Read function pointer */
+  bme68x_read_fptr_t read;
+
+  /*! Write function pointer */
+  bme68x_write_fptr_t write;
+
+  /*! Delay function pointer */
+  bme68x_delay_us_fptr_t delay_us;
+
+  /*! To store interface pointer error */
+  BME68X_INTF_RET_TYPE intf_rslt;
+
+  /*! Store the info messages */
+  uint8_t info_msg;
+};
+
+#endif /* BME68X_DEFS_H_ */
+       /*! @endcond */

--- a/libs/bme68x/Inc/bme68x_driver.h
+++ b/libs/bme68x/Inc/bme68x_driver.h
@@ -1,0 +1,236 @@
+/*******************************************************************************
+ * @file: bme68x_driver.h
+ * @brief: Driver for the Bosch ME68x sensor using STM32 HAL.
+ *
+ * This file provides function prototypes and macros for interfacing
+ * with the BME68x sensor using the STM32 HAL I2C interface.
+ *
+ * @version: 0.1.0
+ * @sources:
+ *   - Bosch BME68x library and Arduino examples
+ *     https://github.com/boschsensortec/Bosch-BME68x-Library
+ ******************************************************************************/
+#pragma once
+
+/**
+ * @brief Required for use of memset.
+ */
+#include <string.h>
+
+/**
+ * @brief Include the STM32 U0 HAL
+ */
+#include "stm32u0xx_hal.h"
+/** @note: As currently written, the Bosch library needs BME68X_DO_NOT_USE_FPU
+ * to be set in order to prevent floating point code from being used. This is currently
+ * set in the CMakeLists.txt file for this driver.
+ */
+#include "bme68x_defs.h"
+#include "bme68x.h"
+
+/* ========================== MACROS ========================== */
+
+/**
+ * @brief Basic error macro
+ * @todo: Consider using in conjunction with the common error types macros
+ */
+#define BME68X_ERROR INT8_C(-1)
+#define BME68X_WARNING INT8_C(1)
+
+/**
+ * @brief Alias the default address, with a left shift to use expected HAL format
+ */
+#define BME68X_ADDR (BME68X_I2C_ADDR_HIGH << 1)
+
+/* ========================== TYPE DEFINITIONS ========================== */
+
+/**
+ * @struct bme68x_sensor_t
+ * @brief Structure to store necessary configuration and data to interact with the sensor over I2C.
+ */
+typedef struct
+{
+  /** Stores the BME68x sensor APIs error code after execution. */
+  int8_t status;
+
+  /** Pointer to the I2C handle (e.g., `&hi2c1`). */
+  I2C_HandleTypeDef *i2c_handle;
+
+  /** BME68X device structure. See `bme68x_defs.h` for details. */
+  struct bme68x_dev device;
+
+  /** Sensor configuration settings, including oversampling and filter coefficients. */
+  struct bme68x_conf conf;
+
+  /** Heater configuration settings. See `bme68x_defs.h` for details. */
+  struct bme68x_heatr_conf heatr_conf;
+
+  /** Structure to store sensor measurement data. */
+  /** @note: Since we're not using floating point, the data will be as follows:
+   *  - Temperature in degrees celsius x100
+   *  - Pressure in Pascal
+   *  - Humidity in % relative humidity x1000
+   *  - Gas resistance in Ohms
+   */
+  struct bme68x_data sensor_data;
+
+  /** Last operation mode used by the sensor. */
+  uint8_t last_opmode;
+} bme68x_sensor_t;
+
+/* ========================== FUNCTION PROTOTYPES ========================== */
+
+/**
+ * @brief Initializes the BME68x sensor.
+ *
+ * Configures the sensor with default settings.
+ *
+ * @param[in,out] bme Pointer to newly initialized bme68x sensor interface
+ * @param[in] i2c_handle Pointer to I2C handle.
+ */
+void bme_init(bme68x_sensor_t *bme, I2C_HandleTypeDef *i2c_handle, bme68x_delay_us_fptr_t delay_fn);
+
+/**
+ * @brief Returns basic status check
+ *
+ * Checks and returns current bme instance status
+ *
+ * @param[in] bme Pointer to bme68x sensor interface
+ * @return 0 for status OK, 1 for warning, -1 for error
+ * @todo: Is this really a necessary or helpful function?
+ */
+int8_t bme_check_status(bme68x_sensor_t *bme);
+
+/**
+ * @brief Set the Temperature, Pressure and Humidity over-sampling using default values.
+ *
+ * Uses as values BME68X_OS_2X, BME68X_OS_16X, and BME68X_OS_1X for os_temp, os_pres,
+ * and os_hum, respectively, for the function bme_set_TPH.
+ *
+ * @param[in] bme Pointer to bme68x sensor interface
+ */
+void bme_set_TPH_default(bme68x_sensor_t *bme);
+
+/**
+ * @brief Set the Temperature, Pressure and Humidity over-sampling.
+ *
+ * Sets bme struct members os_temp, os_pres, and os_hum, and calls bme68x_set_conf,
+ * which sets the number of measurments to perform. See bme68x_defs.h for macro definitions.
+ *
+ * @param[in] bme Pointer to bme68x sensor interface
+ * @param[in] os_temp Number of measurements to perform, BME68X_OS_NONE to BME68X_OS_16X
+ * @param[in] os_pres Number of measurements to perform, BME68X_OS_NONE to BME68X_OS_16X
+ * @param[in] os_hum Number of measurements to perform, BME68X_OS_NONE to BME68X_OS_16X
+ */
+void bme_set_TPH(bme68x_sensor_t *bme, uint8_t os_temp, uint8_t os_pres, uint8_t os_hum);
+
+/**
+ * @brief Set the heater profile for Forced mode
+ *
+ * Determines the gas configuration of the sensor; modify to target
+ * different types of gases.
+ *
+ * @param[in] bme Pointer to bme68x sensor interface
+ * @param[in] temp Heater temperature in degree Celsius
+ * @param[in] dur Heating duration in milliseconds
+ */
+void bme_set_heaterprof(bme68x_sensor_t *bme, uint16_t temp, uint16_t dur);
+
+/**
+ * @brief Set the operation mode
+ *
+ * Set the desired operation mode. Currently supports sleep mode and forced mode for
+ * a single, low-power measurment which may automatically return to sleep mode.
+ * The gas sensor heater only operates during measurement in this mode.
+ *
+ * @param[in] bme Pointer to bme68x sensor interface
+ * @param[in] opmode BME68X_SLEEP_MODE, BME68X_FORCED_MODE
+ */
+void bme_set_opmode(bme68x_sensor_t *bme, uint8_t opmode);
+
+/**
+ * @brief Fetch data from the sensor into the struct's sensor_data buffer
+ *
+ * Calls the bme68x_get_data function, which reads the pressure, temperature,
+ * and humidity and gas data from the sensor, compensates the data, and
+ * stores it in the bme->sensor_data struct member.
+ *
+ * @param[in] bme Pointer to bme68x sensor interface
+ * @return Number of new data fields
+ */
+uint8_t bme_fetch_data(bme68x_sensor_t *bme);
+
+/**
+ * @brief Get the measurement duration in microseconds
+ *
+ * Calls bme68x_get_meas_dur, which calculates the total measurement duration
+ * based on the total number of samples to be taken, as determined by the oversampling
+ * for each value; a wake-up duration of 1ms is added.
+ *
+ * @param[in] bme Pointer to bme68x sensor interface
+ * @param[in] opmode Operation mode of the sensor. Attempts to use the last one if nothing is set
+ * @return Temperature, Pressure, Humidity measurement time in microseconds
+ */
+uint32_t bme_get_meas_dur(bme68x_sensor_t *bme, uint8_t opmode);
+
+/**
+ * @brief Implements the default I2C write transaction
+ *
+ * Sets the write function pointer on the bme68x_dev device struct.
+ * Used throughout the Bosch library to write to the device.
+ *
+ * @param[in] reg_addr Register address of the sensor
+ * @param[in] reg_data Pointer to the data to be written to the sensor
+ * @param[in] length Length of the transfer
+ * @param[in] i2c_handle Pointer to the stm32 I2C peripheral handle
+ * @return 0 if successful, non-zero otherwise
+ */
+int8_t bme_write(uint8_t reg_addr, const uint8_t *reg_data, uint32_t length, void *intf_ptr);
+
+/**
+ * @brief Implements the default I2C read transaction
+ *
+ * Sets the read function pointer on the bme68x_dev device struct.
+ * Used throughout the Bosch library to read from the device.
+ *
+ * @param[in] reg_addr Register address of the sensor
+ * @param[in] reg_data Pointer to the data to write the sensor value to
+ * @param[in] length Length of the transfer
+ * @param[in] i2c_handle Pointer to the stm32 I2C peripheral handle
+ * @return 0 if successful, non-zero otherwise
+ */
+int8_t bme_read(uint8_t reg_addr, uint8_t *reg_data, uint32_t length, void *intf_ptr);
+
+/**
+ * @example main.c
+ *
+ * Example usage of the BME68x sensor driver.
+ * @note: Requires HAL peripheral drivers and initialization, specifically for i2c.
+ * @note: Assumes an I2C_HandleTypeDef hi2c1 instance exists.
+ * @note: Requires a microsecond delay function implemented in the application.
+ *
+ * @code
+ * #include "bme68x_driver.h"
+ *
+ * int main(void) {
+ *     bme68x_sensor_t bme;
+ *     bme_init(&bme, &hi2c1, &delay_us_timer);
+ *     bme_set_TPH_default(&bme);
+ *     bme_set_heaterprof(&bme, 300, 100);
+ *     while (1)
+ *     {
+ *         bme_set_opmode(&bme, BME68X_FORCED_MODE);
+ *         // @todo: May adjust the specific timing function called here, but it should be based on bme_get_meas_dur
+ *         delay_us_timer(bme_get_meas_dur(&bme, BME68X_SLEEP_MODE), &hi2c1);
+ *         int fetch_success = bme_fetch_data(&bme);
+ *         if (fetch_success) {
+ *           debug_print("%d, ", bme.sensor_data.temperature);
+ *           debug_print("%d, ", bme.sensor_data.pressure);
+ *           debug_print("%d, ", bme.sensor_data.humidity);
+ *           debug_print("%d, ", bme.sensor_data.gas_resistance);
+ *           debug_print("%X, \r\n", bme.sensor_data.status);
+ *         }
+ *     }
+ * }
+ * @endcode
+ */

--- a/libs/bme68x/Src/bme68x.c
+++ b/libs/bme68x/Src/bme68x.c
@@ -1,0 +1,1633 @@
+/**
+ * Copyright (c) 2023 Bosch Sensortec GmbH. All rights reserved.
+ *
+ * BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file       bme68x.c
+ * @date       2023-02-07
+ * @version    v4.4.8
+ *
+ */
+
+#include "bme68x.h"
+#include <stdio.h>
+
+/* This internal API is used to read the calibration coefficients */
+static int8_t get_calib_data(struct bme68x_dev *dev);
+
+/* This internal API is used to read variant ID information register status */
+static int8_t read_variant_id(struct bme68x_dev *dev);
+
+/* This internal API is used to calculate the gas wait */
+static uint8_t calc_gas_wait(uint16_t dur);
+
+#ifndef BME68X_USE_FPU
+
+/* This internal API is used to calculate the temperature in integer */
+static int16_t calc_temperature(uint32_t temp_adc, struct bme68x_dev *dev);
+
+/* This internal API is used to calculate the pressure in integer */
+static uint32_t calc_pressure(uint32_t pres_adc, const struct bme68x_dev *dev);
+
+/* This internal API is used to calculate the humidity in integer */
+static uint32_t calc_humidity(uint16_t hum_adc, const struct bme68x_dev *dev);
+
+/* This internal API is used to calculate the gas resistance high */
+static uint32_t calc_gas_resistance_high(uint16_t gas_res_adc, uint8_t gas_range);
+
+/* This internal API is used to calculate the gas resistance low */
+static uint32_t calc_gas_resistance_low(uint16_t gas_res_adc, uint8_t gas_range, const struct bme68x_dev *dev);
+
+/* This internal API is used to calculate the heater resistance using integer */
+static uint8_t calc_res_heat(uint16_t temp, const struct bme68x_dev *dev);
+
+#else
+
+/* This internal API is used to calculate the temperature value in float */
+static float calc_temperature(uint32_t temp_adc, struct bme68x_dev *dev);
+
+/* This internal API is used to calculate the pressure value in float */
+static float calc_pressure(uint32_t pres_adc, const struct bme68x_dev *dev);
+
+/* This internal API is used to calculate the humidity value in float */
+static float calc_humidity(uint16_t hum_adc, const struct bme68x_dev *dev);
+
+/* This internal API is used to calculate the gas resistance high value in float */
+static float calc_gas_resistance_high(uint16_t gas_res_adc, uint8_t gas_range);
+
+/* This internal API is used to calculate the gas resistance low value in float */
+static float calc_gas_resistance_low(uint16_t gas_res_adc, uint8_t gas_range, const struct bme68x_dev *dev);
+
+/* This internal API is used to calculate the heater resistance value using float */
+static uint8_t calc_res_heat(uint16_t temp, const struct bme68x_dev *dev);
+
+#endif
+
+/* This internal API is used to read a single data of the sensor */
+static int8_t read_field_data(uint8_t index, struct bme68x_data *data, struct bme68x_dev *dev);
+
+/* This internal API is used to read all data fields of the sensor */
+static int8_t read_all_field_data(struct bme68x_data *const data[], struct bme68x_dev *dev);
+
+/* This internal API is used to check the bme68x_dev for null pointers */
+static int8_t null_ptr_check(const struct bme68x_dev *dev);
+
+/* This internal API is used to set heater configurations */
+static int8_t set_conf(const struct bme68x_heatr_conf *conf, uint8_t op_mode, uint8_t *nb_conv, struct bme68x_dev *dev);
+
+/* This internal API is used to limit the max value of a parameter */
+static int8_t boundary_check(uint8_t *value, uint8_t max, struct bme68x_dev *dev);
+
+/* This internal API is used to calculate the register value for
+ * shared heater duration */
+static uint8_t calc_heatr_dur_shared(uint16_t dur);
+
+/* This internal API is used to swap two fields */
+static void swap_fields(uint8_t index1, uint8_t index2, struct bme68x_data *field[]);
+
+/* This internal API is used sort the sensor data */
+static void sort_sensor_data(uint8_t low_index, uint8_t high_index, struct bme68x_data *field[]);
+
+/*
+ * @brief       Function to analyze the sensor data
+ *
+ * @param[in]   data    Array of measurement data
+ * @param[in]   n_meas  Number of measurements
+ *
+ * @return Result of API execution status
+ * @retval 0 -> Success
+ * @retval < 0 -> Fail
+ */
+static int8_t analyze_sensor_data(const struct bme68x_data *data, uint8_t n_meas);
+
+/******************************************************************************************/
+/*                                 Global API definitions                                 */
+/******************************************************************************************/
+
+/* @brief This API reads the chip-id of the sensor which is the first step to
+ * verify the sensor and also calibrates the sensor
+ * As this API is the entry point, call this API before using other APIs.
+ */
+int8_t bme68x_init(struct bme68x_dev *dev)
+{
+  int8_t rslt;
+
+  (void)bme68x_soft_reset(dev);
+
+  rslt = bme68x_get_regs(BME68X_REG_CHIP_ID, &dev->chip_id, 1, dev);
+
+  if (rslt == BME68X_OK)
+  {
+    if (dev->chip_id == BME68X_CHIP_ID)
+    {
+      /* Read Variant ID */
+      rslt = read_variant_id(dev);
+
+      if (rslt == BME68X_OK)
+      {
+        /* Get the Calibration data */
+        rslt = get_calib_data(dev);
+      }
+    }
+    else
+    {
+      rslt = BME68X_E_DEV_NOT_FOUND;
+    }
+  }
+
+  return rslt;
+}
+
+/*
+ * @brief This API writes the given data to the register address of the sensor
+ */
+int8_t bme68x_set_regs(const uint8_t *reg_addr, const uint8_t *reg_data, uint32_t len, struct bme68x_dev *dev)
+{
+  int8_t rslt;
+
+  /* Length of the temporary buffer is 2*(length of register)*/
+  uint8_t tmp_buff[BME68X_LEN_INTERLEAVE_BUFF] = {0};
+  uint16_t index;
+
+  /* Check for null pointer in the device structure*/
+  rslt = null_ptr_check(dev);
+  if ((rslt == BME68X_OK) && reg_addr && reg_data)
+  {
+    if ((len > 0) && (len <= (BME68X_LEN_INTERLEAVE_BUFF / 2)))
+    {
+      /* Interleave the 2 arrays */
+      for (index = 0; index < len; index++)
+      {
+        tmp_buff[(2 * index)] = reg_addr[index];
+        tmp_buff[(2 * index) + 1] = reg_data[index];
+      }
+
+      /* Write the interleaved array */
+      if (rslt == BME68X_OK)
+      {
+        dev->intf_rslt = dev->write(tmp_buff[0], &tmp_buff[1], (2 * len) - 1, dev->intf_ptr);
+        if (dev->intf_rslt != 0)
+        {
+          rslt = BME68X_E_COM_FAIL;
+        }
+      }
+    }
+    else
+    {
+      rslt = BME68X_E_INVALID_LENGTH;
+    }
+  }
+  else
+  {
+    rslt = BME68X_E_NULL_PTR;
+  }
+
+  return rslt;
+}
+
+/*
+ * @brief This API reads the data from the given register address of sensor.
+ */
+int8_t bme68x_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct bme68x_dev *dev)
+{
+  int8_t rslt;
+
+  /* Check for null pointer in the device structure*/
+  rslt = null_ptr_check(dev);
+  if ((rslt == BME68X_OK) && reg_data)
+  {
+    dev->intf_rslt = dev->read(reg_addr, reg_data, len, dev->intf_ptr);
+    if (dev->intf_rslt != 0)
+    {
+      rslt = BME68X_E_COM_FAIL;
+    }
+  }
+  else
+  {
+    rslt = BME68X_E_NULL_PTR;
+  }
+
+  return rslt;
+}
+
+/*
+ * @brief This API soft-resets the sensor.
+ */
+int8_t bme68x_soft_reset(struct bme68x_dev *dev)
+{
+  int8_t rslt;
+  uint8_t reg_addr = BME68X_REG_SOFT_RESET;
+
+  /* 0xb6 is the soft reset command */
+  uint8_t soft_rst_cmd = BME68X_SOFT_RESET_CMD;
+
+  /* Check for null pointer in the device structure*/
+  rslt = null_ptr_check(dev);
+  if (rslt == BME68X_OK)
+  {
+    /* Reset the device */
+    if (rslt == BME68X_OK)
+    {
+      rslt = bme68x_set_regs(&reg_addr, &soft_rst_cmd, 1, dev);
+
+      if (rslt == BME68X_OK)
+      {
+        /* Wait for 5ms */
+        dev->delay_us(BME68X_PERIOD_RESET, dev->intf_ptr);
+      }
+    }
+  }
+
+  return rslt;
+}
+
+/*
+ * @brief This API is used to set the oversampling, and filter configuration
+ */
+int8_t bme68x_set_conf(struct bme68x_conf *conf, struct bme68x_dev *dev)
+{
+  int8_t rslt;
+  uint8_t current_op_mode;
+
+  /* Register data starting from BME68X_REG_CTRL_GAS_1(0x71) up to BME68X_REG_CONFIG(0x75) */
+  uint8_t reg_array[BME68X_LEN_CONFIG] = {0x71, 0x72, 0x73, 0x74, 0x75};
+  uint8_t data_array[BME68X_LEN_CONFIG] = {0};
+
+  rslt = bme68x_get_op_mode(&current_op_mode, dev);
+  if (rslt == BME68X_OK)
+  {
+    /* Configure only in the sleep mode */
+    rslt = bme68x_set_op_mode(BME68X_SLEEP_MODE, dev);
+  }
+
+  if (conf == NULL)
+  {
+    rslt = BME68X_E_NULL_PTR;
+  }
+  else if (rslt == BME68X_OK)
+  {
+    /* Read the whole configuration and write it back once later */
+    rslt = bme68x_get_regs(reg_array[0], data_array, BME68X_LEN_CONFIG, dev);
+    dev->info_msg = BME68X_OK;
+    if (rslt == BME68X_OK)
+    {
+      rslt = boundary_check(&conf->filter, BME68X_FILTER_SIZE_127, dev);
+    }
+
+    if (rslt == BME68X_OK)
+    {
+      rslt = boundary_check(&conf->os_temp, BME68X_OS_16X, dev);
+    }
+
+    if (rslt == BME68X_OK)
+    {
+      rslt = boundary_check(&conf->os_pres, BME68X_OS_16X, dev);
+    }
+
+    if (rslt == BME68X_OK)
+    {
+      rslt = boundary_check(&conf->os_hum, BME68X_OS_16X, dev);
+    }
+
+    if (rslt == BME68X_OK)
+    {
+      data_array[4] = BME68X_SET_BITS(data_array[4], BME68X_FILTER, conf->filter);
+      data_array[3] = BME68X_SET_BITS(data_array[3], BME68X_OST, conf->os_temp);
+      data_array[3] = BME68X_SET_BITS(data_array[3], BME68X_OSP, conf->os_pres);
+      data_array[1] = BME68X_SET_BITS_POS_0(data_array[1], BME68X_OSH, conf->os_hum);
+    }
+  }
+
+  if (rslt == BME68X_OK)
+  {
+    rslt = bme68x_set_regs(reg_array, data_array, BME68X_LEN_CONFIG, dev);
+  }
+
+  if ((current_op_mode != BME68X_SLEEP_MODE) && (rslt == BME68X_OK))
+  {
+    rslt = bme68x_set_op_mode(current_op_mode, dev);
+  }
+
+  return rslt;
+}
+
+/*
+ * @brief This API is used to get the oversampling, filter
+ */
+int8_t bme68x_get_conf(struct bme68x_conf *conf, struct bme68x_dev *dev)
+{
+  int8_t rslt;
+
+  /* starting address of the register array for burst read*/
+  uint8_t reg_addr = BME68X_REG_CTRL_GAS_1;
+  uint8_t data_array[BME68X_LEN_CONFIG];
+
+  rslt = bme68x_get_regs(reg_addr, data_array, 5, dev);
+  if (!conf)
+  {
+    rslt = BME68X_E_NULL_PTR;
+  }
+  else if (rslt == BME68X_OK)
+  {
+    conf->os_hum = BME68X_GET_BITS_POS_0(data_array[1], BME68X_OSH);
+    conf->filter = BME68X_GET_BITS(data_array[4], BME68X_FILTER);
+    conf->os_temp = BME68X_GET_BITS(data_array[3], BME68X_OST);
+    conf->os_pres = BME68X_GET_BITS(data_array[3], BME68X_OSP);
+  }
+
+  return rslt;
+}
+
+/*
+ * @brief This API is used to set the operation mode of the sensor
+ */
+int8_t bme68x_set_op_mode(const uint8_t op_mode, struct bme68x_dev *dev)
+{
+  int8_t rslt;
+  uint8_t tmp_pow_mode;
+  uint8_t pow_mode = 0;
+  uint8_t reg_addr = BME68X_REG_CTRL_MEAS;
+
+  /* Call until in sleep */
+  do
+  {
+    rslt = bme68x_get_regs(BME68X_REG_CTRL_MEAS, &tmp_pow_mode, 1, dev);
+    if (rslt == BME68X_OK)
+    {
+      /* Put to sleep before changing mode */
+      pow_mode = (tmp_pow_mode & BME68X_MODE_MSK);
+      if (pow_mode != BME68X_SLEEP_MODE)
+      {
+        tmp_pow_mode &= ~BME68X_MODE_MSK; /* Set to sleep */
+        rslt = bme68x_set_regs(&reg_addr, &tmp_pow_mode, 1, dev);
+        dev->delay_us(BME68X_PERIOD_POLL, dev->intf_ptr);
+      }
+    }
+  } while ((pow_mode != BME68X_SLEEP_MODE) && (rslt == BME68X_OK));
+
+  /* Already in sleep */
+  if ((op_mode != BME68X_SLEEP_MODE) && (rslt == BME68X_OK))
+  {
+    tmp_pow_mode = (tmp_pow_mode & ~BME68X_MODE_MSK) | (op_mode & BME68X_MODE_MSK);
+    rslt = bme68x_set_regs(&reg_addr, &tmp_pow_mode, 1, dev);
+  }
+
+  return rslt;
+}
+
+/*
+ * @brief This API is used to get the operation mode of the sensor.
+ */
+int8_t bme68x_get_op_mode(uint8_t *op_mode, struct bme68x_dev *dev)
+{
+  int8_t rslt;
+  uint8_t mode;
+
+  if (op_mode)
+  {
+    rslt = bme68x_get_regs(BME68X_REG_CTRL_MEAS, &mode, 1, dev);
+
+    /* Masking the other register bit info*/
+    *op_mode = mode & BME68X_MODE_MSK;
+  }
+  else
+  {
+    rslt = BME68X_E_NULL_PTR;
+  }
+
+  return rslt;
+}
+
+/*
+ * @brief This API is used to get the remaining duration that can be used for heating.
+ */
+uint32_t bme68x_get_meas_dur(const uint8_t op_mode, struct bme68x_conf *conf, struct bme68x_dev *dev)
+{
+  int8_t rslt;
+  uint32_t meas_dur = 0; /* Calculate in us */
+  uint32_t meas_cycles;
+  uint8_t os_to_meas_cycles[6] = {0, 1, 2, 4, 8, 16};
+
+  if (conf != NULL)
+  {
+    /* Boundary check for temperature oversampling */
+    rslt = boundary_check(&conf->os_temp, BME68X_OS_16X, dev);
+
+    if (rslt == BME68X_OK)
+    {
+      /* Boundary check for pressure oversampling */
+      rslt = boundary_check(&conf->os_pres, BME68X_OS_16X, dev);
+    }
+
+    if (rslt == BME68X_OK)
+    {
+      /* Boundary check for humidity oversampling */
+      rslt = boundary_check(&conf->os_hum, BME68X_OS_16X, dev);
+    }
+
+    if (rslt == BME68X_OK)
+    {
+      meas_cycles = os_to_meas_cycles[conf->os_temp];
+      meas_cycles += os_to_meas_cycles[conf->os_pres];
+      meas_cycles += os_to_meas_cycles[conf->os_hum];
+
+      /* TPH measurement duration */
+      meas_dur = meas_cycles * UINT32_C(1963);
+      meas_dur += UINT32_C(477 * 4); /* TPH switching duration */
+      meas_dur += UINT32_C(477 * 5); /* Gas measurement duration */
+
+      meas_dur += UINT32_C(1000); /* Wake up duration of 1ms */
+    }
+  }
+
+  return meas_dur;
+}
+
+/*
+ * @brief This API reads the pressure, temperature and humidity and gas data
+ * from the sensor, compensates the data and store it in the bme68x_data
+ * structure instance passed by the user.
+ */
+int8_t bme68x_get_data(uint8_t op_mode, struct bme68x_data *data, uint8_t *n_data, struct bme68x_dev *dev)
+{
+  int8_t rslt;
+  uint8_t new_fields = 0;
+
+  rslt = null_ptr_check(dev);
+  if ((rslt == BME68X_OK) && (data != NULL))
+  {
+    /* Reading the sensor data in forced mode only */
+    if (op_mode == BME68X_FORCED_MODE)
+    {
+      rslt = read_field_data(0, data, dev);
+      if (rslt == BME68X_OK)
+      {
+        if (data->status & BME68X_NEW_DATA_MSK)
+        {
+          new_fields = 1;
+        }
+        else
+        {
+          new_fields = 0;
+          rslt = BME68X_W_NO_NEW_DATA;
+        }
+      }
+    }
+    else
+    {
+      rslt = BME68X_W_DEFINE_OP_MODE;
+    }
+
+    if (n_data == NULL)
+    {
+      rslt = BME68X_E_NULL_PTR;
+    }
+    else
+    {
+      *n_data = new_fields;
+    }
+  }
+  else
+  {
+    rslt = BME68X_E_NULL_PTR;
+  }
+
+  return rslt;
+}
+
+/*
+ * @brief This API is used to set the gas configuration of the sensor.
+ */
+int8_t bme68x_set_heatr_conf(uint8_t op_mode, const struct bme68x_heatr_conf *conf, struct bme68x_dev *dev)
+{
+  int8_t rslt;
+  uint8_t nb_conv = 0;
+  uint8_t hctrl, run_gas = 0;
+  uint8_t ctrl_gas_data[2];
+  uint8_t ctrl_gas_addr[2] = {BME68X_REG_CTRL_GAS_0, BME68X_REG_CTRL_GAS_1};
+
+  if (conf != NULL)
+  {
+    rslt = bme68x_set_op_mode(BME68X_SLEEP_MODE, dev);
+    if (rslt == BME68X_OK)
+    {
+      rslt = set_conf(conf, op_mode, &nb_conv, dev);
+    }
+
+    if (rslt == BME68X_OK)
+    {
+      rslt = bme68x_get_regs(BME68X_REG_CTRL_GAS_0, ctrl_gas_data, 2, dev);
+      if (rslt == BME68X_OK)
+      {
+        if (conf->enable == BME68X_ENABLE)
+        {
+          hctrl = BME68X_ENABLE_HEATER;
+          if (dev->variant_id == BME68X_VARIANT_GAS_HIGH)
+          {
+            run_gas = BME68X_ENABLE_GAS_MEAS_H;
+          }
+          else
+          {
+            run_gas = BME68X_ENABLE_GAS_MEAS_L;
+          }
+        }
+        else
+        {
+          hctrl = BME68X_DISABLE_HEATER;
+          run_gas = BME68X_DISABLE_GAS_MEAS;
+        }
+
+        ctrl_gas_data[0] = BME68X_SET_BITS(ctrl_gas_data[0], BME68X_HCTRL, hctrl);
+        ctrl_gas_data[1] = BME68X_SET_BITS_POS_0(ctrl_gas_data[1], BME68X_NBCONV, nb_conv);
+        ctrl_gas_data[1] = BME68X_SET_BITS(ctrl_gas_data[1], BME68X_RUN_GAS, run_gas);
+        rslt = bme68x_set_regs(ctrl_gas_addr, ctrl_gas_data, 2, dev);
+      }
+    }
+  }
+  else
+  {
+    rslt = BME68X_E_NULL_PTR;
+  }
+
+  return rslt;
+}
+
+/*!
+ * @brief This API is used to get the gas configuration of the sensor.
+ */
+int8_t bme68x_get_heatr_conf(const struct bme68x_heatr_conf *conf, struct bme68x_dev *dev)
+{
+  int8_t rslt = BME68X_OK;
+  uint8_t data_array[10] = {0};
+  uint8_t i;
+
+  if ((conf != NULL) && (conf->heatr_dur_prof != NULL) && (conf->heatr_temp_prof != NULL))
+  {
+    /* FIXME: Add conversion to deg C and ms and add the other parameters */
+    rslt = bme68x_get_regs(BME68X_REG_RES_HEAT0, data_array, 10, dev);
+
+    if (rslt == BME68X_OK)
+    {
+      for (i = 0; i < conf->profile_len; i++)
+      {
+        conf->heatr_temp_prof[i] = data_array[i];
+      }
+
+      rslt = bme68x_get_regs(BME68X_REG_GAS_WAIT0, data_array, 10, dev);
+
+      if (rslt == BME68X_OK)
+      {
+        for (i = 0; i < conf->profile_len; i++)
+        {
+          conf->heatr_dur_prof[i] = data_array[i];
+        }
+      }
+    }
+  }
+  else
+  {
+    rslt = BME68X_E_NULL_PTR;
+  }
+
+  return rslt;
+}
+
+/*
+ * @brief This API performs Self-test of low and high gas variants of BME68X
+ */
+int8_t bme68x_selftest_check(const struct bme68x_dev *dev)
+{
+  int8_t rslt;
+  uint8_t n_fields;
+  uint8_t i = 0;
+  struct bme68x_data data[BME68X_N_MEAS] = {{0}};
+  struct bme68x_dev t_dev;
+  struct bme68x_conf conf;
+  struct bme68x_heatr_conf heatr_conf;
+
+  rslt = null_ptr_check(dev);
+
+  if (rslt == BME68X_OK)
+  {
+    /* Copy required parameters from reference bme68x_dev struct */
+    t_dev.amb_temp = 25;
+    t_dev.read = dev->read;
+    t_dev.write = dev->write;
+    t_dev.delay_us = dev->delay_us;
+    t_dev.intf_ptr = dev->intf_ptr;
+
+    rslt = bme68x_init(&t_dev);
+  }
+
+  if (rslt == BME68X_OK)
+  {
+    /* Set the temperature, pressure and humidity & filter settings */
+    conf.os_hum = BME68X_OS_1X;
+    conf.os_pres = BME68X_OS_16X;
+    conf.os_temp = BME68X_OS_2X;
+
+    /* Set the remaining gas sensor settings and link the heating profile */
+    heatr_conf.enable = BME68X_ENABLE;
+    heatr_conf.heatr_dur = BME68X_HEATR_DUR1;
+    heatr_conf.heatr_temp = BME68X_HIGH_TEMP;
+    rslt = bme68x_set_heatr_conf(BME68X_FORCED_MODE, &heatr_conf, &t_dev);
+    if (rslt == BME68X_OK)
+    {
+      rslt = bme68x_set_conf(&conf, &t_dev);
+      if (rslt == BME68X_OK)
+      {
+        rslt = bme68x_set_op_mode(BME68X_FORCED_MODE, &t_dev); /* Trigger a measurement */
+        if (rslt == BME68X_OK)
+        {
+          /* Wait for the measurement to complete */
+          t_dev.delay_us(BME68X_HEATR_DUR1_DELAY, t_dev.intf_ptr);
+          rslt = bme68x_get_data(BME68X_FORCED_MODE, &data[0], &n_fields, &t_dev);
+          if (rslt == BME68X_OK)
+          {
+            if ((data[0].idac != 0x00) && (data[0].idac != 0xFF) &&
+                (data[0].status & BME68X_GASM_VALID_MSK))
+            {
+              rslt = BME68X_OK;
+            }
+            else
+            {
+              rslt = BME68X_E_SELF_TEST;
+            }
+          }
+        }
+      }
+    }
+
+    heatr_conf.heatr_dur = BME68X_HEATR_DUR2;
+    while ((rslt == BME68X_OK) && (i < BME68X_N_MEAS))
+    {
+      if (i % 2 == 0)
+      {
+        heatr_conf.heatr_temp = BME68X_HIGH_TEMP; /* Higher temperature */
+      }
+      else
+      {
+        heatr_conf.heatr_temp = BME68X_LOW_TEMP; /* Lower temperature */
+      }
+
+      rslt = bme68x_set_heatr_conf(BME68X_FORCED_MODE, &heatr_conf, &t_dev);
+      if (rslt == BME68X_OK)
+      {
+        rslt = bme68x_set_conf(&conf, &t_dev);
+        if (rslt == BME68X_OK)
+        {
+          rslt = bme68x_set_op_mode(BME68X_FORCED_MODE, &t_dev); /* Trigger a measurement */
+          if (rslt == BME68X_OK)
+          {
+            /* Wait for the measurement to complete */
+            t_dev.delay_us(BME68X_HEATR_DUR2_DELAY, t_dev.intf_ptr);
+            rslt = bme68x_get_data(BME68X_FORCED_MODE, &data[i], &n_fields, &t_dev);
+          }
+        }
+      }
+
+      i++;
+    }
+
+    if (rslt == BME68X_OK)
+    {
+      rslt = analyze_sensor_data(data, BME68X_N_MEAS);
+    }
+  }
+
+  return rslt;
+}
+
+/*****************************INTERNAL APIs***********************************************/
+#ifndef BME68X_USE_FPU
+
+/* @brief This internal API is used to calculate the temperature value. */
+static int16_t calc_temperature(uint32_t temp_adc, struct bme68x_dev *dev)
+{
+  int64_t var1;
+  int64_t var2;
+  int64_t var3;
+  int16_t calc_temp;
+
+  /*lint -save -e701 -e702 -e704 */
+  var1 = ((int32_t)temp_adc >> 3) - ((int32_t)dev->calib.par_t1 << 1);
+  var2 = (var1 * (int32_t)dev->calib.par_t2) >> 11;
+  var3 = ((var1 >> 1) * (var1 >> 1)) >> 12;
+  var3 = ((var3) * ((int32_t)dev->calib.par_t3 << 4)) >> 14;
+  dev->calib.t_fine = (int32_t)(var2 + var3);
+  calc_temp = (int16_t)(((dev->calib.t_fine * 5) + 128) >> 8);
+
+  /*lint -restore */
+  return calc_temp;
+}
+
+/* @brief This internal API is used to calculate the pressure value. */
+static uint32_t calc_pressure(uint32_t pres_adc, const struct bme68x_dev *dev)
+{
+  int32_t var1;
+  int32_t var2;
+  int32_t var3;
+  int32_t pressure_comp;
+
+  /* This value is used to check precedence to multiplication or division
+   * in the pressure compensation equation to achieve least loss of precision and
+   * avoiding overflows.
+   * i.e Comparing value, pres_ovf_check = (1 << 31) >> 1
+   */
+  const int32_t pres_ovf_check = INT32_C(0x40000000);
+
+  /*lint -save -e701 -e702 -e713 */
+  var1 = (((int32_t)dev->calib.t_fine) >> 1) - 64000;
+  var2 = ((((var1 >> 2) * (var1 >> 2)) >> 11) * (int32_t)dev->calib.par_p6) >> 2;
+  var2 = var2 + ((var1 * (int32_t)dev->calib.par_p5) << 1);
+  var2 = (var2 >> 2) + ((int32_t)dev->calib.par_p4 << 16);
+  var1 = (((((var1 >> 2) * (var1 >> 2)) >> 13) * ((int32_t)dev->calib.par_p3 << 5)) >> 3) +
+         (((int32_t)dev->calib.par_p2 * var1) >> 1);
+  var1 = var1 >> 18;
+  var1 = ((32768 + var1) * (int32_t)dev->calib.par_p1) >> 15;
+  pressure_comp = 1048576 - pres_adc;
+  pressure_comp = (int32_t)((pressure_comp - (var2 >> 12)) * ((uint32_t)3125));
+  if (pressure_comp >= pres_ovf_check)
+  {
+    pressure_comp = ((pressure_comp / var1) << 1);
+  }
+  else
+  {
+    pressure_comp = ((pressure_comp << 1) / var1);
+  }
+
+  var1 = ((int32_t)dev->calib.par_p9 * (int32_t)(((pressure_comp >> 3) * (pressure_comp >> 3)) >> 13)) >> 12;
+  var2 = ((int32_t)(pressure_comp >> 2) * (int32_t)dev->calib.par_p8) >> 13;
+  var3 =
+      ((int32_t)(pressure_comp >> 8) * (int32_t)(pressure_comp >> 8) * (int32_t)(pressure_comp >> 8) *
+       (int32_t)dev->calib.par_p10) >>
+      17;
+  pressure_comp = (int32_t)(pressure_comp) + ((var1 + var2 + var3 + ((int32_t)dev->calib.par_p7 << 7)) >> 4);
+
+  /*lint -restore */
+  return (uint32_t)pressure_comp;
+}
+
+/* This internal API is used to calculate the humidity in integer */
+static uint32_t calc_humidity(uint16_t hum_adc, const struct bme68x_dev *dev)
+{
+  int32_t var1;
+  int32_t var2;
+  int32_t var3;
+  int32_t var4;
+  int32_t var5;
+  int32_t var6;
+  int32_t temp_scaled;
+  int32_t calc_hum;
+
+  /*lint -save -e702 -e704 */
+  temp_scaled = (((int32_t)dev->calib.t_fine * 5) + 128) >> 8;
+  var1 = (int32_t)(hum_adc - ((int32_t)((int32_t)dev->calib.par_h1 * 16))) -
+         (((temp_scaled * (int32_t)dev->calib.par_h3) / ((int32_t)100)) >> 1);
+  var2 =
+      ((int32_t)dev->calib.par_h2 *
+       (((temp_scaled * (int32_t)dev->calib.par_h4) / ((int32_t)100)) +
+        (((temp_scaled * ((temp_scaled * (int32_t)dev->calib.par_h5) / ((int32_t)100))) >> 6) / ((int32_t)100)) +
+        (int32_t)(1 << 14))) >>
+      10;
+  var3 = var1 * var2;
+  var4 = (int32_t)dev->calib.par_h6 << 7;
+  var4 = ((var4) + ((temp_scaled * (int32_t)dev->calib.par_h7) / ((int32_t)100))) >> 4;
+  var5 = ((var3 >> 14) * (var3 >> 14)) >> 10;
+  var6 = (var4 * var5) >> 1;
+  calc_hum = (((var3 + var6) >> 10) * ((int32_t)1000)) >> 12;
+  if (calc_hum > 100000) /* Cap at 100%rH */
+  {
+    calc_hum = 100000;
+  }
+  else if (calc_hum < 0)
+  {
+    calc_hum = 0;
+  }
+
+  /*lint -restore */
+  return (uint32_t)calc_hum;
+}
+
+/* This internal API is used to calculate the gas resistance low */
+static uint32_t calc_gas_resistance_low(uint16_t gas_res_adc, uint8_t gas_range, const struct bme68x_dev *dev)
+{
+  int64_t var1;
+  uint64_t var2;
+  int64_t var3;
+  uint32_t calc_gas_res;
+  uint32_t lookup_table1[16] = {
+      UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2147483647),
+      UINT32_C(2126008810), UINT32_C(2147483647), UINT32_C(2130303777), UINT32_C(2147483647), UINT32_C(2147483647),
+      UINT32_C(2143188679), UINT32_C(2136746228), UINT32_C(2147483647), UINT32_C(2126008810), UINT32_C(2147483647),
+      UINT32_C(2147483647)};
+  uint32_t lookup_table2[16] = {
+      UINT32_C(4096000000), UINT32_C(2048000000), UINT32_C(1024000000), UINT32_C(512000000), UINT32_C(255744255),
+      UINT32_C(127110228), UINT32_C(64000000), UINT32_C(32258064), UINT32_C(16016016), UINT32_C(8000000), UINT32_C(4000000), UINT32_C(2000000), UINT32_C(1000000), UINT32_C(500000), UINT32_C(250000), UINT32_C(125000)};
+
+  /*lint -save -e704 */
+  var1 = (int64_t)((1340 + (5 * (int64_t)dev->calib.range_sw_err)) * ((int64_t)lookup_table1[gas_range])) >> 16;
+  var2 = (((int64_t)((int64_t)gas_res_adc << 15) - (int64_t)(16777216)) + var1);
+  var3 = (((int64_t)lookup_table2[gas_range] * (int64_t)var1) >> 9);
+  calc_gas_res = (uint32_t)((var3 + ((int64_t)var2 >> 1)) / (int64_t)var2);
+
+  /*lint -restore */
+  return calc_gas_res;
+}
+
+/* This internal API is used to calculate the gas resistance */
+static uint32_t calc_gas_resistance_high(uint16_t gas_res_adc, uint8_t gas_range)
+{
+  uint32_t calc_gas_res;
+  uint32_t var1 = UINT32_C(262144) >> gas_range;
+  int32_t var2 = (int32_t)gas_res_adc - INT32_C(512);
+
+  var2 *= INT32_C(3);
+  var2 = INT32_C(4096) + var2;
+
+  /* multiplying 10000 then dividing then multiplying by 100 instead of multiplying by 1000000 to prevent overflow */
+  calc_gas_res = (UINT32_C(10000) * var1) / (uint32_t)var2;
+  calc_gas_res = calc_gas_res * 100;
+
+  return calc_gas_res;
+}
+
+/* This internal API is used to calculate the heater resistance value using integer */
+static uint8_t calc_res_heat(uint16_t temp, const struct bme68x_dev *dev)
+{
+  uint8_t heatr_res;
+  int32_t var1;
+  int32_t var2;
+  int32_t var3;
+  int32_t var4;
+  int32_t var5;
+  int32_t heatr_res_x100;
+
+  if (temp > 400) /* Cap temperature */
+  {
+    temp = 400;
+  }
+
+  var1 = (((int32_t)dev->amb_temp * dev->calib.par_gh3) / 1000) * 256;
+  var2 = (dev->calib.par_gh1 + 784) * (((((dev->calib.par_gh2 + 154009) * temp * 5) / 100) + 3276800) / 10);
+  var3 = var1 + (var2 / 2);
+  var4 = (var3 / (dev->calib.res_heat_range + 4));
+  var5 = (131 * dev->calib.res_heat_val) + 65536;
+  heatr_res_x100 = (int32_t)(((var4 / var5) - 250) * 34);
+  heatr_res = (uint8_t)((heatr_res_x100 + 50) / 100);
+
+  return heatr_res;
+}
+
+#else
+
+/* @brief This internal API is used to calculate the temperature value. */
+static float calc_temperature(uint32_t temp_adc, struct bme68x_dev *dev)
+{
+  float var1;
+  float var2;
+  float calc_temp;
+
+  /* calculate var1 data */
+  var1 = ((((float)temp_adc / 16384.0f) - ((float)dev->calib.par_t1 / 1024.0f)) * ((float)dev->calib.par_t2));
+
+  /* calculate var2 data */
+  var2 =
+      (((((float)temp_adc / 131072.0f) - ((float)dev->calib.par_t1 / 8192.0f)) *
+        (((float)temp_adc / 131072.0f) - ((float)dev->calib.par_t1 / 8192.0f))) *
+       ((float)dev->calib.par_t3 * 16.0f));
+
+  /* t_fine value*/
+  dev->calib.t_fine = (var1 + var2);
+
+  /* compensated temperature data*/
+  calc_temp = ((dev->calib.t_fine) / 5120.0f);
+
+  return calc_temp;
+}
+
+/* @brief This internal API is used to calculate the pressure value. */
+static float calc_pressure(uint32_t pres_adc, const struct bme68x_dev *dev)
+{
+  float var1;
+  float var2;
+  float var3;
+  float calc_pres;
+
+  var1 = (((float)dev->calib.t_fine / 2.0f) - 64000.0f);
+  var2 = var1 * var1 * (((float)dev->calib.par_p6) / (131072.0f));
+  var2 = var2 + (var1 * ((float)dev->calib.par_p5) * 2.0f);
+  var2 = (var2 / 4.0f) + (((float)dev->calib.par_p4) * 65536.0f);
+  var1 = (((((float)dev->calib.par_p3 * var1 * var1) / 16384.0f) + ((float)dev->calib.par_p2 * var1)) / 524288.0f);
+  var1 = ((1.0f + (var1 / 32768.0f)) * ((float)dev->calib.par_p1));
+  calc_pres = (1048576.0f - ((float)pres_adc));
+
+  /* Avoid exception caused by division by zero */
+  if ((int)var1 != 0)
+  {
+    calc_pres = (((calc_pres - (var2 / 4096.0f)) * 6250.0f) / var1);
+    var1 = (((float)dev->calib.par_p9) * calc_pres * calc_pres) / 2147483648.0f;
+    var2 = calc_pres * (((float)dev->calib.par_p8) / 32768.0f);
+    var3 = ((calc_pres / 256.0f) * (calc_pres / 256.0f) * (calc_pres / 256.0f) * (dev->calib.par_p10 / 131072.0f));
+    calc_pres = (calc_pres + (var1 + var2 + var3 + ((float)dev->calib.par_p7 * 128.0f)) / 16.0f);
+  }
+  else
+  {
+    calc_pres = 0;
+  }
+
+  return calc_pres;
+}
+
+/* This internal API is used to calculate the humidity in integer */
+static float calc_humidity(uint16_t hum_adc, const struct bme68x_dev *dev)
+{
+  float calc_hum;
+  float var1;
+  float var2;
+  float var3;
+  float var4;
+  float temp_comp;
+
+  /* compensated temperature data*/
+  temp_comp = ((dev->calib.t_fine) / 5120.0f);
+  var1 = (float)((float)hum_adc) -
+         (((float)dev->calib.par_h1 * 16.0f) + (((float)dev->calib.par_h3 / 2.0f) * temp_comp));
+  var2 = var1 *
+         ((float)(((float)dev->calib.par_h2 / 262144.0f) *
+                  (1.0f + (((float)dev->calib.par_h4 / 16384.0f) * temp_comp) +
+                   (((float)dev->calib.par_h5 / 1048576.0f) * temp_comp * temp_comp))));
+  var3 = (float)dev->calib.par_h6 / 16384.0f;
+  var4 = (float)dev->calib.par_h7 / 2097152.0f;
+  calc_hum = var2 + ((var3 + (var4 * temp_comp)) * var2 * var2);
+  if (calc_hum > 100.0f)
+  {
+    calc_hum = 100.0f;
+  }
+  else if (calc_hum < 0.0f)
+  {
+    calc_hum = 0.0f;
+  }
+
+  return calc_hum;
+}
+
+/* This internal API is used to calculate the gas resistance low value in float */
+static float calc_gas_resistance_low(uint16_t gas_res_adc, uint8_t gas_range, const struct bme68x_dev *dev)
+{
+  float calc_gas_res;
+  float var1;
+  float var2;
+  float var3;
+  float gas_res_f = gas_res_adc;
+  float gas_range_f = (1U << gas_range); /*lint !e790 / Suspicious truncation, integral to float */
+  const float lookup_k1_range[16] = {
+      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, -0.8f, 0.0f, 0.0f, -0.2f, -0.5f, 0.0f, -1.0f, 0.0f, 0.0f};
+  const float lookup_k2_range[16] = {
+      0.0f, 0.0f, 0.0f, 0.0f, 0.1f, 0.7f, 0.0f, -0.8f, -0.1f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+  var1 = (1340.0f + (5.0f * dev->calib.range_sw_err));
+  var2 = (var1) * (1.0f + lookup_k1_range[gas_range] / 100.0f);
+  var3 = 1.0f + (lookup_k2_range[gas_range] / 100.0f);
+  calc_gas_res = 1.0f / (float)(var3 * (0.000000125f) * gas_range_f * (((gas_res_f - 512.0f) / var2) + 1.0f));
+
+  return calc_gas_res;
+}
+
+/* This internal API is used to calculate the gas resistance value in float */
+static float calc_gas_resistance_high(uint16_t gas_res_adc, uint8_t gas_range)
+{
+  float calc_gas_res;
+  uint32_t var1 = UINT32_C(262144) >> gas_range;
+  int32_t var2 = (int32_t)gas_res_adc - INT32_C(512);
+
+  var2 *= INT32_C(3);
+  var2 = INT32_C(4096) + var2;
+
+  calc_gas_res = 1000000.0f * (float)var1 / (float)var2;
+
+  return calc_gas_res;
+}
+
+/* This internal API is used to calculate the heater resistance value using float */
+static uint8_t calc_res_heat(uint16_t temp, const struct bme68x_dev *dev)
+{
+  float var1;
+  float var2;
+  float var3;
+  float var4;
+  float var5;
+  uint8_t res_heat;
+
+  if (temp > 400) /* Cap temperature */
+  {
+    temp = 400;
+  }
+
+  var1 = (((float)dev->calib.par_gh1 / (16.0f)) + 49.0f);
+  var2 = ((((float)dev->calib.par_gh2 / (32768.0f)) * (0.0005f)) + 0.00235f);
+  var3 = ((float)dev->calib.par_gh3 / (1024.0f));
+  var4 = (var1 * (1.0f + (var2 * (float)temp)));
+  var5 = (var4 + (var3 * (float)dev->amb_temp));
+  res_heat =
+      (uint8_t)(3.4f *
+                ((var5 * (4 / (4 + (float)dev->calib.res_heat_range)) *
+                  (1 / (1 + ((float)dev->calib.res_heat_val * 0.002f)))) -
+                 25));
+
+  return res_heat;
+}
+
+#endif
+
+/* This internal API is used to calculate the gas wait */
+static uint8_t calc_gas_wait(uint16_t dur)
+{
+  uint8_t factor = 0;
+  uint8_t durval;
+
+  if (dur >= 0xfc0)
+  {
+    durval = 0xff; /* Max duration*/
+  }
+  else
+  {
+    while (dur > 0x3F)
+    {
+      dur = dur / 4;
+      factor += 1;
+    }
+
+    durval = (uint8_t)(dur + (factor * 64));
+  }
+
+  return durval;
+}
+
+/* This internal API is used to read a single data of the sensor */
+static int8_t read_field_data(uint8_t index, struct bme68x_data *data, struct bme68x_dev *dev)
+{
+  int8_t rslt = BME68X_OK;
+  uint8_t buff[BME68X_LEN_FIELD] = {0};
+  uint8_t gas_range_l, gas_range_h;
+  uint32_t adc_temp;
+  uint32_t adc_pres;
+  uint16_t adc_hum;
+  uint16_t adc_gas_res_low, adc_gas_res_high;
+  uint8_t tries = 5;
+
+  while ((tries) && (rslt == BME68X_OK))
+  {
+    rslt = bme68x_get_regs(((uint8_t)(BME68X_REG_FIELD0 + (index * BME68X_LEN_FIELD_OFFSET))),
+                           buff,
+                           (uint16_t)BME68X_LEN_FIELD,
+                           dev);
+    if (!data)
+    {
+      rslt = BME68X_E_NULL_PTR;
+      break;
+    }
+
+    data->status = buff[0] & BME68X_NEW_DATA_MSK;
+    data->gas_index = buff[0] & BME68X_GAS_INDEX_MSK;
+    data->meas_index = buff[1];
+
+    /* read the raw data from the sensor */
+    adc_pres = (uint32_t)(((uint32_t)buff[2] * 4096) | ((uint32_t)buff[3] * 16) | ((uint32_t)buff[4] / 16));
+    adc_temp = (uint32_t)(((uint32_t)buff[5] * 4096) | ((uint32_t)buff[6] * 16) | ((uint32_t)buff[7] / 16));
+    adc_hum = (uint16_t)(((uint32_t)buff[8] * 256) | (uint32_t)buff[9]);
+    adc_gas_res_low = (uint16_t)((uint32_t)buff[13] * 4 | (((uint32_t)buff[14]) / 64));
+    adc_gas_res_high = (uint16_t)((uint32_t)buff[15] * 4 | (((uint32_t)buff[16]) / 64));
+    gas_range_l = buff[14] & BME68X_GAS_RANGE_MSK;
+    gas_range_h = buff[16] & BME68X_GAS_RANGE_MSK;
+    if (dev->variant_id == BME68X_VARIANT_GAS_HIGH)
+    {
+      data->status |= buff[16] & BME68X_GASM_VALID_MSK;
+      data->status |= buff[16] & BME68X_HEAT_STAB_MSK;
+    }
+    else
+    {
+      data->status |= buff[14] & BME68X_GASM_VALID_MSK;
+      data->status |= buff[14] & BME68X_HEAT_STAB_MSK;
+    }
+
+    if ((data->status & BME68X_NEW_DATA_MSK) && (rslt == BME68X_OK))
+    {
+      rslt = bme68x_get_regs(BME68X_REG_RES_HEAT0 + data->gas_index, &data->res_heat, 1, dev);
+      if (rslt == BME68X_OK)
+      {
+        rslt = bme68x_get_regs(BME68X_REG_IDAC_HEAT0 + data->gas_index, &data->idac, 1, dev);
+      }
+
+      if (rslt == BME68X_OK)
+      {
+        rslt = bme68x_get_regs(BME68X_REG_GAS_WAIT0 + data->gas_index, &data->gas_wait, 1, dev);
+      }
+
+      if (rslt == BME68X_OK)
+      {
+        data->temperature = calc_temperature(adc_temp, dev);
+        data->pressure = calc_pressure(adc_pres, dev);
+        data->humidity = calc_humidity(adc_hum, dev);
+        if (dev->variant_id == BME68X_VARIANT_GAS_HIGH)
+        {
+          data->gas_resistance = calc_gas_resistance_high(adc_gas_res_high, gas_range_h);
+        }
+        else
+        {
+          data->gas_resistance = calc_gas_resistance_low(adc_gas_res_low, gas_range_l, dev);
+        }
+
+        break;
+      }
+    }
+
+    if (rslt == BME68X_OK)
+    {
+      dev->delay_us(BME68X_PERIOD_POLL, dev->intf_ptr);
+    }
+
+    tries--;
+  }
+
+  return rslt;
+}
+
+/* This internal API is used to read all data fields of the sensor */
+static int8_t read_all_field_data(struct bme68x_data *const data[], struct bme68x_dev *dev)
+{
+  int8_t rslt = BME68X_OK;
+  uint8_t buff[BME68X_LEN_FIELD * 3] = {0};
+  uint8_t gas_range_l, gas_range_h;
+  uint32_t adc_temp;
+  uint32_t adc_pres;
+  uint16_t adc_hum;
+  uint16_t adc_gas_res_low, adc_gas_res_high;
+  uint8_t off;
+  uint8_t set_val[30] = {0}; /* idac, res_heat, gas_wait */
+  uint8_t i;
+
+  if (!data[0] && !data[1] && !data[2])
+  {
+    rslt = BME68X_E_NULL_PTR;
+  }
+
+  if (rslt == BME68X_OK)
+  {
+    rslt = bme68x_get_regs(BME68X_REG_FIELD0, buff, (uint32_t)BME68X_LEN_FIELD * 3, dev);
+  }
+
+  if (rslt == BME68X_OK)
+  {
+    rslt = bme68x_get_regs(BME68X_REG_IDAC_HEAT0, set_val, 30, dev);
+  }
+
+  for (i = 0; ((i < 3) && (rslt == BME68X_OK)); i++)
+  {
+    off = (uint8_t)(i * BME68X_LEN_FIELD);
+    data[i]->status = buff[off] & BME68X_NEW_DATA_MSK;
+    data[i]->gas_index = buff[off] & BME68X_GAS_INDEX_MSK;
+    data[i]->meas_index = buff[off + 1];
+
+    /* read the raw data from the sensor */
+    adc_pres =
+        (uint32_t)(((uint32_t)buff[off + 2] * 4096) | ((uint32_t)buff[off + 3] * 16) |
+                   ((uint32_t)buff[off + 4] / 16));
+    adc_temp =
+        (uint32_t)(((uint32_t)buff[off + 5] * 4096) | ((uint32_t)buff[off + 6] * 16) |
+                   ((uint32_t)buff[off + 7] / 16));
+    adc_hum = (uint16_t)(((uint32_t)buff[off + 8] * 256) | (uint32_t)buff[off + 9]);
+    adc_gas_res_low = (uint16_t)((uint32_t)buff[off + 13] * 4 | (((uint32_t)buff[off + 14]) / 64));
+    adc_gas_res_high = (uint16_t)((uint32_t)buff[off + 15] * 4 | (((uint32_t)buff[off + 16]) / 64));
+    gas_range_l = buff[off + 14] & BME68X_GAS_RANGE_MSK;
+    gas_range_h = buff[off + 16] & BME68X_GAS_RANGE_MSK;
+    if (dev->variant_id == BME68X_VARIANT_GAS_HIGH)
+    {
+      data[i]->status |= buff[off + 16] & BME68X_GASM_VALID_MSK;
+      data[i]->status |= buff[off + 16] & BME68X_HEAT_STAB_MSK;
+    }
+    else
+    {
+      data[i]->status |= buff[off + 14] & BME68X_GASM_VALID_MSK;
+      data[i]->status |= buff[off + 14] & BME68X_HEAT_STAB_MSK;
+    }
+
+    data[i]->idac = set_val[data[i]->gas_index];
+    data[i]->res_heat = set_val[10 + data[i]->gas_index];
+    data[i]->gas_wait = set_val[20 + data[i]->gas_index];
+    data[i]->temperature = calc_temperature(adc_temp, dev);
+    data[i]->pressure = calc_pressure(adc_pres, dev);
+    data[i]->humidity = calc_humidity(adc_hum, dev);
+    if (dev->variant_id == BME68X_VARIANT_GAS_HIGH)
+    {
+      data[i]->gas_resistance = calc_gas_resistance_high(adc_gas_res_high, gas_range_h);
+    }
+    else
+    {
+      data[i]->gas_resistance = calc_gas_resistance_low(adc_gas_res_low, gas_range_l, dev);
+    }
+  }
+
+  return rslt;
+}
+
+/* This internal API is used to limit the max value of a parameter */
+static int8_t boundary_check(uint8_t *value, uint8_t max, struct bme68x_dev *dev)
+{
+  int8_t rslt;
+
+  rslt = null_ptr_check(dev);
+  if ((value != NULL) && (rslt == BME68X_OK))
+  {
+    /* Check if value is above maximum value */
+    if (*value > max)
+    {
+      /* Auto correct the invalid value to maximum value */
+      *value = max;
+      dev->info_msg |= BME68X_I_PARAM_CORR;
+    }
+  }
+  else
+  {
+    rslt = BME68X_E_NULL_PTR;
+  }
+
+  return rslt;
+}
+
+/* This internal API is used to check the bme68x_dev for null pointers */
+static int8_t null_ptr_check(const struct bme68x_dev *dev)
+{
+  int8_t rslt = BME68X_OK;
+
+  if ((dev == NULL) || (dev->read == NULL) || (dev->write == NULL) || (dev->delay_us == NULL))
+  {
+    /* Device structure pointer is not valid */
+    rslt = BME68X_E_NULL_PTR;
+  }
+
+  return rslt;
+}
+
+/* This internal API is used to set heater configurations */
+static int8_t set_conf(const struct bme68x_heatr_conf *conf, uint8_t op_mode, uint8_t *nb_conv, struct bme68x_dev *dev)
+{
+  int8_t rslt = BME68X_OK;
+  uint8_t write_len = 0;
+  uint8_t rh_reg_addr[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  uint8_t rh_reg_data[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  uint8_t gw_reg_addr[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  uint8_t gw_reg_data[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+  switch (op_mode)
+  {
+  case BME68X_FORCED_MODE:
+    rh_reg_addr[0] = BME68X_REG_RES_HEAT0;
+    rh_reg_data[0] = calc_res_heat(conf->heatr_temp, dev);
+    gw_reg_addr[0] = BME68X_REG_GAS_WAIT0;
+    gw_reg_data[0] = calc_gas_wait(conf->heatr_dur);
+    (*nb_conv) = 0;
+    write_len = 1;
+    break;
+  default:
+    rslt = BME68X_W_DEFINE_OP_MODE;
+  }
+
+  if (rslt == BME68X_OK)
+  {
+    rslt = bme68x_set_regs(rh_reg_addr, rh_reg_data, write_len, dev);
+  }
+
+  if (rslt == BME68X_OK)
+  {
+    rslt = bme68x_set_regs(gw_reg_addr, gw_reg_data, write_len, dev);
+  }
+
+  return rslt;
+}
+
+/* This internal API is used to calculate the register value for
+ * shared heater duration */
+static uint8_t calc_heatr_dur_shared(uint16_t dur)
+{
+  uint8_t factor = 0;
+  uint8_t heatdurval;
+
+  if (dur >= 0x783)
+  {
+    heatdurval = 0xff; /* Max duration */
+  }
+  else
+  {
+    /* Step size of 0.477ms */
+    dur = (uint16_t)(((uint32_t)dur * 1000) / 477);
+    while (dur > 0x3F)
+    {
+      dur = dur >> 2;
+      factor += 1;
+    }
+
+    heatdurval = (uint8_t)(dur + (factor * 64));
+  }
+
+  return heatdurval;
+}
+
+/* This internal API is used sort the sensor data */
+static void sort_sensor_data(uint8_t low_index, uint8_t high_index, struct bme68x_data *field[])
+{
+  int16_t meas_index1;
+  int16_t meas_index2;
+
+  meas_index1 = (int16_t)field[low_index]->meas_index;
+  meas_index2 = (int16_t)field[high_index]->meas_index;
+  if ((field[low_index]->status & BME68X_NEW_DATA_MSK) && (field[high_index]->status & BME68X_NEW_DATA_MSK))
+  {
+    int16_t diff = meas_index2 - meas_index1;
+    if (((diff > -3) && (diff < 0)) || (diff > 2))
+    {
+      swap_fields(low_index, high_index, field);
+    }
+  }
+  else if (field[high_index]->status & BME68X_NEW_DATA_MSK)
+  {
+    swap_fields(low_index, high_index, field);
+  }
+
+  /* Sorting field data
+   *
+   * The 3 fields are filled in a fixed order with data in an incrementing
+   * 8-bit sub-measurement index which looks like
+   * Field index | Sub-meas index
+   *      0      |        0
+   *      1      |        1
+   *      2      |        2
+   *      0      |        3
+   *      1      |        4
+   *      2      |        5
+   *      ...
+   *      0      |        252
+   *      1      |        253
+   *      2      |        254
+   *      0      |        255
+   *      1      |        0
+   *      2      |        1
+   *
+   * The fields are sorted in a way so as to always deal with only a snapshot
+   * of comparing 2 fields at a time. The order being
+   * field0 & field1
+   * field0 & field2
+   * field1 & field2
+   * Here the oldest data should be in field0 while the newest is in field2.
+   * In the following documentation, field0's position would referred to as
+   * the lowest and field2 as the highest.
+   *
+   * In order to sort we have to consider the following cases,
+   *
+   * Case A: No fields have new data
+   *     Then do not sort, as this data has already been read.
+   *
+   * Case B: Higher field has new data
+   *     Then the new field get's the lowest position.
+   *
+   * Case C: Both fields have new data
+   *     We have to put the oldest sample in the lowest position. Since the
+   *     sub-meas index contains in essence the age of the sample, we calculate
+   *     the difference between the higher field and the lower field.
+   *     Here we have 3 sub-cases,
+   *     Case 1: Regular read without overwrite
+   *         Field index | Sub-meas index
+   *              0      |        3
+   *              1      |        4
+   *
+   *         Field index | Sub-meas index
+   *              0      |        3
+   *              2      |        5
+   *
+   *         The difference is always <= 2. There is no need to swap as the
+   *         oldest sample is already in the lowest position.
+   *
+   *     Case 2: Regular read with an overflow and without an overwrite
+   *         Field index | Sub-meas index
+   *              0      |        255
+   *              1      |        0
+   *
+   *         Field index | Sub-meas index
+   *              0      |        254
+   *              2      |        0
+   *
+   *         The difference is always <= -3. There is no need to swap as the
+   *         oldest sample is already in the lowest position.
+   *
+   *     Case 3: Regular read with overwrite
+   *         Field index | Sub-meas index
+   *              0      |        6
+   *              1      |        4
+   *
+   *         Field index | Sub-meas index
+   *              0      |        6
+   *              2      |        5
+   *
+   *         The difference is always > -3. There is a need to swap as the
+   *         oldest sample is not in the lowest position.
+   *
+   *     Case 4: Regular read with overwrite and overflow
+   *         Field index | Sub-meas index
+   *              0      |        0
+   *              1      |        254
+   *
+   *         Field index | Sub-meas index
+   *              0      |        0
+   *              2      |        255
+   *
+   *         The difference is always > 2. There is a need to swap as the
+   *         oldest sample is not in the lowest position.
+   *
+   * To summarize, we have to swap when
+   *     - The higher field has new data and the lower field does not.
+   *     - If both fields have new data, then the difference of sub-meas index
+   *         between the higher field and the lower field creates the
+   *         following condition for swapping.
+   *         - (diff > -3) && (diff < 0), combination of cases 1, 2, and 3.
+   *         - diff > 2, case 4.
+   *
+   *     Here the limits of -3 and 2 derive from the fact that there are 3 fields.
+   *     These values decrease or increase respectively if the number of fields increases.
+   */
+}
+
+/* This internal API is used sort the sensor data */
+static void swap_fields(uint8_t index1, uint8_t index2, struct bme68x_data *field[])
+{
+  struct bme68x_data *temp;
+
+  temp = field[index1];
+  field[index1] = field[index2];
+  field[index2] = temp;
+}
+
+/* This Function is to analyze the sensor data */
+static int8_t analyze_sensor_data(const struct bme68x_data *data, uint8_t n_meas)
+{
+  int8_t rslt = BME68X_OK;
+  uint8_t self_test_failed = 0, i;
+  uint32_t cent_res = 0;
+
+  if ((data[0].temperature < BME68X_MIN_TEMPERATURE) || (data[0].temperature > BME68X_MAX_TEMPERATURE))
+  {
+    self_test_failed++;
+  }
+
+  if ((data[0].pressure < BME68X_MIN_PRESSURE) || (data[0].pressure > BME68X_MAX_PRESSURE))
+  {
+    self_test_failed++;
+  }
+
+  if ((data[0].humidity < BME68X_MIN_HUMIDITY) || (data[0].humidity > BME68X_MAX_HUMIDITY))
+  {
+    self_test_failed++;
+  }
+
+  for (i = 0; i < n_meas; i++) /* Every gas measurement should be valid */
+  {
+    if (!(data[i].status & BME68X_GASM_VALID_MSK))
+    {
+      self_test_failed++;
+    }
+  }
+
+  if (n_meas >= 6)
+  {
+    cent_res = (uint32_t)((5 * (data[3].gas_resistance + data[5].gas_resistance)) / (2 * data[4].gas_resistance));
+  }
+
+  if (cent_res < 6)
+  {
+    self_test_failed++;
+  }
+
+  if (self_test_failed)
+  {
+    rslt = BME68X_E_SELF_TEST;
+  }
+
+  return rslt;
+}
+
+/* This internal API is used to read the calibration coefficients */
+static int8_t get_calib_data(struct bme68x_dev *dev)
+{
+  int8_t rslt;
+  uint8_t coeff_array[BME68X_LEN_COEFF_ALL];
+
+  rslt = bme68x_get_regs(BME68X_REG_COEFF1, coeff_array, BME68X_LEN_COEFF1, dev);
+  if (rslt == BME68X_OK)
+  {
+    rslt = bme68x_get_regs(BME68X_REG_COEFF2, &coeff_array[BME68X_LEN_COEFF1], BME68X_LEN_COEFF2, dev);
+  }
+
+  if (rslt == BME68X_OK)
+  {
+    rslt = bme68x_get_regs(BME68X_REG_COEFF3,
+                           &coeff_array[BME68X_LEN_COEFF1 + BME68X_LEN_COEFF2],
+                           BME68X_LEN_COEFF3,
+                           dev);
+  }
+
+  if (rslt == BME68X_OK)
+  {
+    /* Temperature related coefficients */
+    dev->calib.par_t1 =
+        (uint16_t)(BME68X_CONCAT_BYTES(coeff_array[BME68X_IDX_T1_MSB], coeff_array[BME68X_IDX_T1_LSB]));
+    dev->calib.par_t2 =
+        (int16_t)(BME68X_CONCAT_BYTES(coeff_array[BME68X_IDX_T2_MSB], coeff_array[BME68X_IDX_T2_LSB]));
+    dev->calib.par_t3 = (int8_t)(coeff_array[BME68X_IDX_T3]);
+
+    /* Pressure related coefficients */
+    dev->calib.par_p1 =
+        (uint16_t)(BME68X_CONCAT_BYTES(coeff_array[BME68X_IDX_P1_MSB], coeff_array[BME68X_IDX_P1_LSB]));
+    dev->calib.par_p2 =
+        (int16_t)(BME68X_CONCAT_BYTES(coeff_array[BME68X_IDX_P2_MSB], coeff_array[BME68X_IDX_P2_LSB]));
+    dev->calib.par_p3 = (int8_t)coeff_array[BME68X_IDX_P3];
+    dev->calib.par_p4 =
+        (int16_t)(BME68X_CONCAT_BYTES(coeff_array[BME68X_IDX_P4_MSB], coeff_array[BME68X_IDX_P4_LSB]));
+    dev->calib.par_p5 =
+        (int16_t)(BME68X_CONCAT_BYTES(coeff_array[BME68X_IDX_P5_MSB], coeff_array[BME68X_IDX_P5_LSB]));
+    dev->calib.par_p6 = (int8_t)(coeff_array[BME68X_IDX_P6]);
+    dev->calib.par_p7 = (int8_t)(coeff_array[BME68X_IDX_P7]);
+    dev->calib.par_p8 =
+        (int16_t)(BME68X_CONCAT_BYTES(coeff_array[BME68X_IDX_P8_MSB], coeff_array[BME68X_IDX_P8_LSB]));
+    dev->calib.par_p9 =
+        (int16_t)(BME68X_CONCAT_BYTES(coeff_array[BME68X_IDX_P9_MSB], coeff_array[BME68X_IDX_P9_LSB]));
+    dev->calib.par_p10 = (uint8_t)(coeff_array[BME68X_IDX_P10]);
+
+    /* Humidity related coefficients */
+    dev->calib.par_h1 =
+        (uint16_t)(((uint16_t)coeff_array[BME68X_IDX_H1_MSB] << 4) |
+                   (coeff_array[BME68X_IDX_H1_LSB] & BME68X_BIT_H1_DATA_MSK));
+    dev->calib.par_h2 =
+        (uint16_t)(((uint16_t)coeff_array[BME68X_IDX_H2_MSB] << 4) | ((coeff_array[BME68X_IDX_H2_LSB]) >> 4));
+    dev->calib.par_h3 = (int8_t)coeff_array[BME68X_IDX_H3];
+    dev->calib.par_h4 = (int8_t)coeff_array[BME68X_IDX_H4];
+    dev->calib.par_h5 = (int8_t)coeff_array[BME68X_IDX_H5];
+    dev->calib.par_h6 = (uint8_t)coeff_array[BME68X_IDX_H6];
+    dev->calib.par_h7 = (int8_t)coeff_array[BME68X_IDX_H7];
+
+    /* Gas heater related coefficients */
+    dev->calib.par_gh1 = (int8_t)coeff_array[BME68X_IDX_GH1];
+    dev->calib.par_gh2 =
+        (int16_t)(BME68X_CONCAT_BYTES(coeff_array[BME68X_IDX_GH2_MSB], coeff_array[BME68X_IDX_GH2_LSB]));
+    dev->calib.par_gh3 = (int8_t)coeff_array[BME68X_IDX_GH3];
+
+    /* Other coefficients */
+    dev->calib.res_heat_range = ((coeff_array[BME68X_IDX_RES_HEAT_RANGE] & BME68X_RHRANGE_MSK) / 16);
+    dev->calib.res_heat_val = (int8_t)coeff_array[BME68X_IDX_RES_HEAT_VAL];
+    dev->calib.range_sw_err = ((int8_t)(coeff_array[BME68X_IDX_RANGE_SW_ERR] & BME68X_RSERROR_MSK)) / 16;
+  }
+
+  return rslt;
+}
+
+/* This internal API is used to read variant ID information from the register */
+static int8_t read_variant_id(struct bme68x_dev *dev)
+{
+  int8_t rslt;
+  uint8_t reg_data = 0;
+
+  /* Read variant ID information register */
+  rslt = bme68x_get_regs(BME68X_REG_VARIANT_ID, &reg_data, 1, dev);
+
+  if (rslt == BME68X_OK)
+  {
+    dev->variant_id = reg_data;
+  }
+
+  return rslt;
+}

--- a/libs/bme68x/Src/bme68x_driver.c
+++ b/libs/bme68x/Src/bme68x_driver.c
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * @file: bme68x_driver.c
+ * @brief: Driver for the BME68x sensor using STM32 HAL.
+ *
+ * This file contains the implementation of functions for configuring
+ * and reading data from the BME68x sensor using STM32 HAL.
+ *
+ * @version: 0.1.0
+ * @sources:
+ *   - Bosch BME68x library and Arduino examples
+ *     https://github.com/boschsensortec/Bosch-BME68x-Library
+ ******************************************************************************/
+
+#include "bme68x_driver.h"
+
+/* ========================== FUNCTION IMPLEMENTATIONS ========================== */
+
+/** Initializes the BME68x sensor interface */
+void bme_init(bme68x_sensor_t *bme, I2C_HandleTypeDef *i2c_handle, bme68x_delay_us_fptr_t delay_fn)
+{
+  if (bme == NULL)
+  {
+    return;
+  }
+
+  // Zero-initialize all members
+  memset(bme, 0, sizeof(bme68x_sensor_t));
+
+  // Assign the I2C handle
+  bme->i2c_handle = i2c_handle;
+
+  //
+  // Set default values
+  //
+  bme->device.intf_ptr = i2c_handle;
+  /** @todo (maybe) Assign variant ID on bme struct */
+  bme->device.read = &bme_read;
+  bme->device.write = &bme_write;
+  bme->device.delay_us = delay_fn;
+  bme->status = BME68X_OK;
+  // Typical ambient temperature in Celsius
+  bme->device.amb_temp = 25;
+  // Assume sensor starts in sleep mode
+  bme->last_opmode = BME68X_SLEEP_MODE;
+
+  bme68x_init(&bme->device);
+}
+
+/** Returns basic status check */
+int8_t bme_check_status(bme68x_sensor_t *bme)
+{
+  if (bme->status < BME68X_OK)
+  {
+    return BME68X_ERROR;
+  }
+  else if (bme->status > BME68X_OK)
+  {
+    return BME68X_WARNING;
+  }
+  else
+  {
+    return BME68X_OK;
+  }
+}
+
+/** Set the Temperature, Pressure and Humidity over-sampling using default values. */
+void bme_set_TPH_default(bme68x_sensor_t *bme)
+{
+  bme_set_TPH(bme, BME68X_OS_2X, BME68X_OS_16X, BME68X_OS_1X);
+}
+
+/** Set the Temperature, Pressure and Humidity over-sampling.*/
+void bme_set_TPH(bme68x_sensor_t *bme, uint8_t os_temp, uint8_t os_pres, uint8_t os_hum)
+{
+  bme->status = bme68x_get_conf(&bme->conf, &bme->device);
+
+  if (bme->status == BME68X_OK)
+  {
+    bme->conf.os_hum = os_hum;
+    bme->conf.os_temp = os_temp;
+    bme->conf.os_pres = os_pres;
+
+    bme->status = bme68x_set_conf(&bme->conf, &bme->device);
+  }
+}
+
+/** Set the heater profile for Forced mode */
+void bme_set_heaterprof(bme68x_sensor_t *bme, uint16_t temp, uint16_t dur)
+{
+  bme->heatr_conf.enable = BME68X_ENABLE;
+  bme->heatr_conf.heatr_temp = temp;
+  bme->heatr_conf.heatr_dur = dur;
+
+  bme->status = bme68x_set_heatr_conf(BME68X_FORCED_MODE, &bme->heatr_conf, &bme->device);
+}
+
+/** Set the operation mode */
+void bme_set_opmode(bme68x_sensor_t *bme, uint8_t opmode)
+{
+  bme->status = bme68x_set_op_mode(opmode, &bme->device);
+  if ((bme->status == BME68X_OK) && (opmode != BME68X_SLEEP_MODE))
+    bme->last_opmode = opmode;
+}
+
+/** Fetch data from the sensor into the struct's sensor_data buffer */
+uint8_t bme_fetch_data(bme68x_sensor_t *bme)
+{
+  uint8_t n_fields = 0;
+  bme->status = bme68x_get_data(bme->last_opmode, &bme->sensor_data, &n_fields, &bme->device);
+  return n_fields;
+}
+
+/** Get the measurement duration in microseconds*/
+uint32_t bme_get_meas_dur(bme68x_sensor_t *bme, uint8_t opmode)
+{
+  if (opmode == BME68X_SLEEP_MODE)
+    opmode = bme->last_opmode;
+
+  return bme68x_get_meas_dur(opmode, &bme->conf, &bme->device);
+}
+
+/** Implements the default microsecond delay callback */
+int8_t bme_write(uint8_t reg_addr, const uint8_t *reg_data, uint32_t length, void *intf_ptr)
+{
+  // Cast the I2C handle back to the correct type
+  I2C_HandleTypeDef *i2c_handle = (I2C_HandleTypeDef *)intf_ptr;
+
+  // For multi-byte writes, we need pairs of register addresses and data,
+  // since the sensor does *not* auto-increment for multi-byte writes.
+  // Create a buffer with enough space for all register/data pairs
+  uint8_t buffer[length * 2];
+
+  // Fill the buffer with register/data pairs
+  /** @todo: Determine max size needed for this buffer */
+  for (uint16_t i = 0; i < length; i++)
+  {
+    buffer[i * 2] = reg_addr + i;
+    buffer[i * 2 + 1] = reg_data[i];
+  }
+
+  // Transmit all register/data pairs in a single transaction
+  if (HAL_I2C_Master_Transmit(i2c_handle, BME68X_ADDR, buffer, length * 2, HAL_MAX_DELAY) != HAL_OK)
+  {
+    // Error in transmission
+    return -1;
+  }
+
+  // Return 0 on success
+  return 0;
+}
+
+/** Implements the default microsecond delay callback */
+int8_t bme_read(uint8_t reg_addr, uint8_t *reg_data, uint32_t length, void *intf_ptr)
+{
+  // Cast the I2C handle back to the correct type
+  I2C_HandleTypeDef *i2c_handle = (I2C_HandleTypeDef *)intf_ptr;
+
+  /** @todo: Consider using HAL_I2C_Mem_Read in a single transaction */
+  // Send the register address (1 byte)
+  if (HAL_I2C_Master_Transmit(i2c_handle, BME68X_ADDR, &reg_addr, 1, HAL_MAX_DELAY) != HAL_OK)
+  {
+    // Error in transmitting register address
+    return -1;
+  }
+
+  // Read the requested number of bytes
+  // The sensor auto-increments for I2C reads
+  if (HAL_I2C_Master_Receive(i2c_handle, BME68X_ADDR, reg_data, length, HAL_MAX_DELAY) != HAL_OK)
+  {
+    // Error in reading data
+    return -1;
+  }
+
+  // Return 0 on success
+  return 0;
+}

--- a/libs/bme68x/bme68x.md
+++ b/libs/bme68x/bme68x.md
@@ -1,0 +1,204 @@
+# Bosch BME68x Driver
+
+## Overview
+
+This driver is used to initialize and configure a Bosch 68x sensor (specifically the [688](https://www.bosch-sensortec.com/products/environmental-sensors/gas-sensors/bme688/) or [680](https://www.bosch-sensortec.com/products/environmental-sensors/gas-sensors/bme680/)), and retrieve data for temperature, pressure, humidity, and a resistance value reflecting gas composition. Communication with the sensor takes place over I2C, using an I2C handle created with the STM32 HAL.
+
+Driver functionality is focused on low-power environments with minimal code storage. There may be features supported by the 688, for example, that are not supported here because they have requirements that are outside the anticipated operating context for the Pico Balloon platform.
+
+### Driver Structure
+
+The driver is based on a combination of a library provided by Bosch with a simplified interface using the STM32 HAL. The files containing code from Bosch include `bme68x_def.h`, `bme68x.h`, and `bme68x.c`. The STM32 HAL support and simplified interface is contained in `bme68x_driver.h` and `bme68x_driver.c`.
+
+The Bosch code was retrieved from the [Bosch-BME68x-Library github repo](https://github.com/boschsensortec/Bosch-BME68x-Library/tree/master) and checked into this repository in whole. The library was then reduced to support only the necessary functionality. See the [Design Decisions](#design-decisions) below for additional detail.
+
+In addition, the Bosch library github repo contained an Arduino library written in C++. This served as a model for many of the functions provided in this driver, with appropriate modifications made for the STM32.
+
+### Example Usage
+
+The following example shows creation and initialization of a `bme68x_sensor_t` struct, which contains a pointer to an I2C handle previously initialized in application code, in addition to a pointer to a function from the application that should be used when a microsecond delay is needed. The struct also contains status, a BME68x device struct, configuration, sensor data, and the last operation mode.
+
+After initialization, configuration is performed, using default oversampling values for the temperature, pressure, and humidity measurements, and a heater configuration of 300 deg C for 100ms in forced mode.
+
+Data is then fetched from the sensor repeatedly in a loop. As noted above, the delay function should be implemented in application code, for example using a hardware timer and function defined in `tim.c`, but the microsecond delay should still be based on the return value from the `bme_get_meas_dur` function.
+
+```c
+#include "bme68x_driver.h"
+
+int main(void) {
+  bme68x_sensor_t bme;
+  bme_init(&bme, &hi2c1, &delay_us_timer);
+  bme_set_TPH_default(&bme);
+  bme_set_heaterprof(&bme, 300, 100);
+
+  while (1)
+  {
+    bme_set_opmode(&bme, BME68X_FORCED_MODE);
+    /** @todo: May adjust the specific timing function called here, but it should be based on bme_get_meas_dur */
+    delay_us_timer(bme_get_meas_dur(&bme, BME68X_SLEEP_MODE), &hi2c1);
+    int fetch_success = bme_fetch_data(&bme);
+    if (fetch_success) {
+          debug_print("%d, ", bme.sensor_data.temperature);
+          debug_print("%d, ", bme.sensor_data.pressure);
+          debug_print("%d, ", bme.sensor_data.humidity);
+          debug_print("%d, ", bme.sensor_data.gas_resistance);
+          debug_print("%X, \r\n", bme.sensor_data.status);
+        }
+  }
+}
+
+```
+
+## Driver API
+
+### `bme68x_sensor_t` struct
+
+Structure to store necessary configuration and data to interact with the sensor over I2C. Contains as members the structs `bme68x_dev`, `bme68x_conf`, `bme68x_heatr_conf`, and `bme68x_data`, which are defined in `bme68x_defs.h`. Also contains an `I2C_HandleTypeDef` pointer to allow I2C communication using STM32 HAL I2C functions, and a pointer to a microsecond delay function defined by the application.
+
+**NOTE**: The delay function signature is currently determined by the original one used by the Bosch library developers. The function signature is fairly simple (it accepts a `uint32_t` microsecond delay value and a `void *` interface pointer), but if desired, the Bosch library code may be modified to accommodate an alternate signature.
+
+### `bme_init()`
+
+Configures the sensor with default settings.
+
+**Parameters:**
+- `bme`: Pointer to newly initialized bme68x sensor interface
+- `i2c_handle`: Pointer to I2C handle
+- `delay_fn`: Pointer to a microsecond delay function
+
+### `bme_check_status()`
+
+Checks and returns current bme instance status. Returns 0 for status OK, 1 for warning, -1 for error. **NOTE**: This may be modified in the future to leverage the common error type construction defined in [libs/common/Inc/error_types.h](../common/Inc/error_types.h).
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+
+**Returns:**
+- `int8_t`: 0 for status 0, 1 for warning, -1 for error
+
+### `bme_set_TPH_default()`
+
+Set the Temperature, Pressure and Humidity over-sampling using the following defaults: 2 samples for temperature, 16 for pressure, 1 for humidity. These defaults are based on those used in the self-test check function provided in the Bosch library.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+
+### `bme_set_TPH()`
+
+Set the Temperature, Pressure and Humidity over-sampling.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+- `os_temp`: Number of temperature measurements to perform, BME68X_OS_NONE to BME68X_OS_16X
+- `os_pres`: Number of pressure measurements to perform, BME68X_OS_NONE to BME68X_OS_16X
+- `os_hum`: Number of humidity measurements to perform, BME68X_OS_NONE to BME68X_OS_16X
+
+### `bme_set_heaterprof()`
+
+Set the heater profile for Forced mode. Parameters for temperature and duration may be adjusted depending on the gas profile being targeted.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+- `temp`: Heater temperature in degree Celsius
+- `dur`: Heating duration in milliseconds
+
+### `bme_set_opmode()`
+
+Set the operation mode. Currently supports sleep mode and forced mode for a single, low-power measurment which may automatically return to sleep mode. The gas sensor heater only operates during measurement in this mode.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+- `opmode`: BME68X_SLEEP_MODE or BME68X_FORCED_MODE
+
+### `bme_fetch_data()`
+
+Fetch data from the sensor into the struct's sensor_data buffer. **NOTE**: This should typically return 1, indicating new data was retrieved. This value could be more than 1 when implementing support for parallel or sequential data retrieval modes.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+
+**Returns:**
+- `uint8_t`: Number of new data fields
+
+### `bme_get_meas_dur()`
+
+Get the measurement duration in microseconds. This is the total measurement duration based on the total number of samples to be taken, as determined by the oversampling for each value.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+- `opmode`: Operation mode of the sensor. Attempts to use the last one if nothing is set
+
+**Returns:**
+- `uint32_t`: Measurement duration in microseconds
+
+### `bme_write()`
+
+Implements the default I2C write transaction. This is leveraged by the Bosch library to perform writes to the device over I2C. It should typically not be necessary for application code to call this function directly, though it may be useful in troubleshooting.
+
+**Parameters:**
+- `reg_addr`: Register address of the sensor
+- `reg_data`: Pointer to the data to be written to the sensor
+- `length`: Length of the transfer
+- `i2c_handle`: Pointer to the stm32 I2C peripheral handle
+
+**Returns:**
+- `int8_t`: 0 if successful, non-zero otherwise
+
+### `bme_read()`
+
+Implements the default I2C read transaction. This is leveraged by the Bosch library to perform reads from the device over I2C. It should typically not be necessary for application code to call this function directly, though it may be useful in troubleshooting.
+
+**Parameters:**
+- `reg_addr`: Register address of the sensor
+- `reg_data`: Pointer to the data to write the sensor value(s) to
+- `length`: Length of the transfer
+- `i2c_handle`: Pointer to the stm32 I2C peripheral handle
+
+**Returns:**
+- `int8_t`: 0 if successful, non-zero otherwise
+
+## Design Decisions
+
+As noted above in the overview, some functionality has been removed from the Bosch-provided library. This was based on expected operating conditions, considering factors such as power usage and flash storage. Below is an outline of functionality that was removed from the Bosch library, as well as functionality that was left in place, with brief explanations for each.
+
+The entirety of the Bosch library was checked into the prior codebase, [PicoAPRS-Firmware](https://github.com/coffee-and-telesense/PicoAPRS-Firmware), so retrieving and re-implementing removed features in the future should be possible if desired.
+
+### Removed functionality
+
+**Parallel and sequential modes**
+
+Parallel mode is not supported by the BME680, and in the case of the 688, it is described as requiring more power than forced mode. Parallel mode also does not support automatically returning to sleep mode. In addition, the greatest benefit from parallel mode is likely achieved by using the AI training features possible with the 688. These features require usage of a static library provied by Bosch. At the current time, it is assumed that we should prioritize a smaller library size over utilizing this feature.
+
+Sequential mode is not documented in the 688 datasheet, but it seems likely this is also intended to be leveraged along with the AI training on targeting specific gas profiles. It allows for including multiple temperature and duration settings to be used for sequential measurements.
+
+**SPI support**
+
+We do not currently intend to support the SPI protocol for communication with sensors.
+
+### Maintained functionality
+
+**Conditional compilation for a kernel context**
+
+The `bme68x_defs.h` file provided by Bosch includes some conditional compilation sections (e.g. `#ifdef __KERNEL__`) which seem to be aimed at supporting usage of the library within a Linux kernel context. These have been left in place to allow for the possibility of RTOS usage in the future.
+
+**Conditional compilation for hardware floating point support**
+
+It is not necessarily anticipated that we will use floating point hardware, but the Bosch driver includes support for it. As with the above conditional compilation for a kernel context, this code does not contribute to the overall driver size as long as compilation correctly includes the `BME68X_DO_NOT_USE_FPU` definition. This is currently added in the `CMakeLists.txt` file for the driver.
+
+**Currently unused functions**
+
+There are a few functions from the Bosch library that are not currently in use, but could possibly be useful in the future (e.g. `sort_sensor_data`, `calc_heatr_dur_shared`, and `read_all_field_data`). These have been left in place under the assumption that the application will be compiled with some reasonable level of optimization which will result in their removal from the compiled binary.
+
+## Next Steps
+
+**Validate humidity measurements**
+
+The humidity measurements currently appear to be returning the max value consistently. This may be an individual sensor-specific problem, it could be related to a timing issue, or possibly an oversampling setting. First steps to resolve are to test on additional sensors, adjust the oversampling setting, or simply step through the code with a debugger and see if it's possible to retrieve a valid humidity measurement at any stage.
+
+**Create non-blocking version**
+
+We should allow for the driver to be used in a non-blocking manner, leveraging interrupts.
+
+**Ensure compatibility with an RTOS**
+
+This work is TBD, but the maintenance of the conditional compilation for the Linux kernel supports this work.

--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Shared Libraries CMakeLists.txt
+cmake_minimum_required(VERSION 3.22)
+project(common)
+
+# Create the common library
+add_library(common STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/Src/logging.c
+)
+
+# Define include directories
+target_include_directories(common PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/Inc
+)
+
+
+message(STATUS "Building common library")
+
+# Link with required dependencies
+target_link_libraries(common PUBLIC
+    stm32cubemx
+    # Add dependencies here
+)
+
+message(STATUS "Added common library")

--- a/tests/bme68x_test/CMakeLists.txt
+++ b/tests/bme68x_test/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(bme68x_test test_bme68x.c)
+
+target_sources(bme68x_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_bme68x.c
+)
+
+target_link_libraries(bme68x_test PRIVATE 
+    stm32cubemx
+    bme68x
+)

--- a/tests/bme68x_test/CMakeLists.txt
+++ b/tests/bme68x_test/CMakeLists.txt
@@ -6,5 +6,6 @@ target_sources(bme68x_test PRIVATE
 
 target_link_libraries(bme68x_test PRIVATE 
     stm32cubemx
+    common
     bme68x
 )

--- a/tests/bme68x_test/test_bme68x.c
+++ b/tests/bme68x_test/test_bme68x.c
@@ -3,6 +3,7 @@
 #include "tim.h"
 #include "usart.h"
 #include "gpio.h"
+#include "logging.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
@@ -12,7 +13,6 @@
 // BME68x driver code
 #include "bme68x_driver.h"
 
-void debug_print(const char *fmt, ...);
 // Declare extern private functions from CubeMX
 extern void SystemClock_Config(void);
 
@@ -30,13 +30,15 @@ int main(void)
   MX_I2C1_Init();
   MX_TIM2_Init();
 
+  debug_init(&huart2);
+
   if (HAL_I2C_IsDeviceReady(&hi2c1, BME68X_ADDR, 3, HAL_MAX_DELAY) == HAL_OK)
   {
-    debug_print("Sensor is ready\r\n");
+    printf("Sensor is ready\r\n");
   }
   else
   {
-    debug_print("Sensor not responding\r\n");
+    printf("Sensor not responding\r\n");
   }
 
   // Create bme interface struct and initialize it
@@ -47,12 +49,12 @@ int main(void)
   {
     if (bme_status == BME68X_ERROR)
     {
-      debug_print("Sensor error:" + bme_status);
+      printf("Sensor error:" + bme_status);
       return BME68X_ERROR;
     }
     else if (bme_status == BME68X_WARNING)
     {
-      debug_print("Sensor Warning:" + bme_status);
+      printf("Sensor Warning:" + bme_status);
     }
   }
   // Set temp, pressure, humidity oversampling configuration
@@ -65,7 +67,7 @@ int main(void)
 
   uint8_t sensor_id;
   bme_read(0xD0, &sensor_id, 4, &hi2c1);
-  debug_print("Received sensor ID: 0x%X\r\n", sensor_id);
+  printf("Received sensor ID: 0x%X\r\n", sensor_id);
 
   /* USER CODE END 2 */
 
@@ -80,17 +82,17 @@ int main(void)
     int fetch_success = bme_fetch_data(&bme);
     if (fetch_success)
     {
-      debug_print("Temperature: %d.%02d°C, ",
+      printf("Temperature: %d.%02d°C, ",
                   bme.sensor_data.temperature / 100,
                   (bme.sensor_data.temperature % 100));
-      debug_print("Pressure: %d Pa, ", bme.sensor_data.pressure);
-      debug_print("Humidity: %d.%03d%%, ",
+      printf("Pressure: %lu Pa, ", bme.sensor_data.pressure);
+      printf("Humidity: %lu.%03lu%%, ",
                   bme.sensor_data.humidity / 1000,
                   (bme.sensor_data.humidity % 1000));
-      debug_print("Gas Resistance: %d.%03d kΩ, ",
+      printf("Gas Resistance: %lu.%03lu kΩ, ",
                   bme.sensor_data.gas_resistance / 1000,
                   (bme.sensor_data.gas_resistance % 1000));
-      debug_print("Status: 0x%X\r\n", bme.sensor_data.status);
+      printf("Status: 0x%X\r\n", bme.sensor_data.status);
     }
 
     // The "blink" code is a simple verification of program execution,
@@ -98,37 +100,5 @@ int main(void)
     // HAL_GPIO_TogglePin(LD2_GPIO_Port, LD2_Pin);
     HAL_Delay(1000);
 
-  }
-}
-
-void debug_print(const char *fmt, ...)
-{
-  char buffer[128]; // Adjust size as needed
-  va_list args;
-  va_start(args, fmt);
-
-  // Format the string
-  int result = vsnprintf(buffer, sizeof(buffer), fmt, args);
-  va_end(args);
-
-  if (result < 0)
-  {
-    // Handle snprintf error
-    HAL_UART_Transmit(&DEBUG_UART, (uint8_t *)"vsnprintf error\n", 16, 100);
-  }
-  else
-  {
-    // Ensure null termination
-    buffer[sizeof(buffer) - 1] = '\0';
-
-    // Get the actual length
-    size_t len = (size_t)result;
-    if (len > sizeof(buffer))
-    {
-      len = sizeof(buffer) - 1;
-    }
-
-    // Transmit the formatted message
-    HAL_UART_Transmit(&DEBUG_UART, (uint8_t *)buffer, len, 100);
   }
 }

--- a/tests/bme68x_test/test_bme68x.c
+++ b/tests/bme68x_test/test_bme68x.c
@@ -1,0 +1,134 @@
+#include "main.h"
+#include "i2c.h"
+#include "tim.h"
+#include "usart.h"
+#include "gpio.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+
+#define DEBUG_UART huart2
+
+// BME68x driver code
+#include "bme68x_driver.h"
+
+void debug_print(const char *fmt, ...);
+// Declare extern private functions from CubeMX
+extern void SystemClock_Config(void);
+
+int main(void)
+{
+  /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
+  HAL_Init();
+
+  /* Configure the system clock */
+  SystemClock_Config();
+
+  /* Initialize all configured peripherals */
+  MX_GPIO_Init();
+  MX_USART2_UART_Init();
+  MX_I2C1_Init();
+  MX_TIM2_Init();
+
+  if (HAL_I2C_IsDeviceReady(&hi2c1, BME68X_ADDR, 3, HAL_MAX_DELAY) == HAL_OK)
+  {
+    debug_print("Sensor is ready\r\n");
+  }
+  else
+  {
+    debug_print("Sensor not responding\r\n");
+  }
+
+  // Create bme interface struct and initialize it
+  bme68x_sensor_t bme;
+  bme_init(&bme, &hi2c1, &delay_us_timer);
+  // Check status, should be 0 for OK
+  int bme_status = bme_check_status(&bme);
+  {
+    if (bme_status == BME68X_ERROR)
+    {
+      debug_print("Sensor error:" + bme_status);
+      return BME68X_ERROR;
+    }
+    else if (bme_status == BME68X_WARNING)
+    {
+      debug_print("Sensor Warning:" + bme_status);
+    }
+  }
+  // Set temp, pressure, humidity oversampling configuration
+  // Trying with defaults
+  bme_set_TPH_default(&bme);
+  // Alternatively, could set each to sample only once:
+  // bme_set_TPH(&bme, BME68X_OS_1X, BME68X_OS_1X, BME68X_OS_1X);
+  // Set the heater configuration to 300 deg C for 100ms for Forced mode
+  bme_set_heaterprof(&bme, 300, 100);
+
+  uint8_t sensor_id;
+  bme_read(0xD0, &sensor_id, 4, &hi2c1);
+  debug_print("Received sensor ID: 0x%X\r\n", sensor_id);
+
+  /* USER CODE END 2 */
+
+  /* Infinite loop */
+  while (1)
+  {
+    // Set to forced mode, which takes a single sample and returns to sleep mode
+    bme_set_opmode(&bme, BME68X_FORCED_MODE);
+    /** @todo: May adjust the specific timing function called here, but it should be based on bme_get_meas_dur */
+    delay_us_timer(bme_get_meas_dur(&bme, BME68X_SLEEP_MODE), &hi2c1);
+    // Fetch data
+    int fetch_success = bme_fetch_data(&bme);
+    if (fetch_success)
+    {
+      debug_print("Temperature: %d.%02d°C, ",
+                  bme.sensor_data.temperature / 100,
+                  (bme.sensor_data.temperature % 100));
+      debug_print("Pressure: %d Pa, ", bme.sensor_data.pressure);
+      debug_print("Humidity: %d.%03d%%, ",
+                  bme.sensor_data.humidity / 1000,
+                  (bme.sensor_data.humidity % 1000));
+      debug_print("Gas Resistance: %d.%03d kΩ, ",
+                  bme.sensor_data.gas_resistance / 1000,
+                  (bme.sensor_data.gas_resistance % 1000));
+      debug_print("Status: 0x%X\r\n", bme.sensor_data.status);
+    }
+
+    // The "blink" code is a simple verification of program execution,
+    // separate from the BME68x sensor testing above
+    // HAL_GPIO_TogglePin(LD2_GPIO_Port, LD2_Pin);
+    HAL_Delay(1000);
+
+  }
+}
+
+void debug_print(const char *fmt, ...)
+{
+  char buffer[128]; // Adjust size as needed
+  va_list args;
+  va_start(args, fmt);
+
+  // Format the string
+  int result = vsnprintf(buffer, sizeof(buffer), fmt, args);
+  va_end(args);
+
+  if (result < 0)
+  {
+    // Handle snprintf error
+    HAL_UART_Transmit(&DEBUG_UART, (uint8_t *)"vsnprintf error\n", 16, 100);
+  }
+  else
+  {
+    // Ensure null termination
+    buffer[sizeof(buffer) - 1] = '\0';
+
+    // Get the actual length
+    size_t len = (size_t)result;
+    if (len > sizeof(buffer))
+    {
+      len = sizeof(buffer) - 1;
+    }
+
+    // Transmit the formatted message
+    HAL_UART_Transmit(&DEBUG_UART, (uint8_t *)buffer, len, 100);
+  }
+}


### PR DESCRIPTION
Bringing the Bosch BME68x sensor driver over from the [old repo](https://github.com/coffee-and-telesense/PicoAPRS-Firmware), attempting to make the fewest changes possible at this stage in order to produce a successful build. Relevant output from the cmake build in VSCode is showing below:

```sh
[build] [23/23] Linking C executable tests/bme68x_test/bme68x_test.elf
[build] Memory region         Used Size  Region Size  %age Used
[build]              RAM:        2736 B        32 KB      8.35%
[build]            FLASH:       40636 B       256 KB     15.50%
[driver] Build completed: 00:00:00.952
[build] Build finished with exit code 0
```

The main changes from the original include the following:

**Driver changes**
- Changing the `include` for the stm32 HAL in `bme68x_driver.h` from `stm32l4xx_hal_i2c.h` to `stm32u0xx_hal.h`, which obviously changes the family from L4 to U0, but also references the entire HAL instead of just the I2C component. The build was failing when using just the I2C component for U0, probably due to changes in our overall build process. I think this is still correct though (maybe more correct than previously).
- Need to include `string.h` in `bme68x_driver.h` for `memset`. Again, probably due to how we were building in the previous repo, but it seems like if this is needed for `memset`, then including it explicitly should be ok. We can certainly revisit this though if needed.

**Test application changes**
- We don't currently have the same logging utility, so I added the basic `debug_print` directly to the test file for now. We should decide if we want to bring the logging utility over as-is, or move to a different logging implementation.
- I just commented out the blinky bit for now. I'll likely add that back as it is sort of a nice confirmation that the program is running when troubleshooting, but it seems fine to leave it as-is for the time being.

**Delay function changes**
- I was running into a build error where `HAL_TIM_PeriodElapsedCallback` had duplicate definitions. I'm not sure if the HAL changed in this regard, but based on examination of the existing `HAL_TIM_PeriodElapsedCallback`, it seemed that the appropriate thing to do was to implement a `app_timer_elapsed_hook`, which would be called from the HAL callback.